### PR TITLE
feat: add structured procurement intent parsing

### DIFF
--- a/agents/architect.py
+++ b/agents/architect.py
@@ -37,6 +37,8 @@ Aura automates B2B procurement with built-in compliance. Your pipeline:
   3. Closer  → settles payment via AP2 protocol
 
 When the user submits a procurement request:
+0. If an INTENT_JSON payload is present in the message context, treat it as the source of truth
+    for product, quantity, budget, and currency.
 1. Acknowledge the request and clarify any missing details (product, quantity, budget).
 2. Hand off to the AuraPipeline sub-agent to execute Scout → Sentinel → Closer.
 3. Summarise the final outcome for the user:

--- a/main.py
+++ b/main.py
@@ -25,6 +25,11 @@ from google.adk.sessions import InMemorySessionService
 from google.genai import types as genai_types
 
 from agents.architect import architect
+from tools.intent_tools import (
+    build_clarification_message,
+    build_structured_procurement_prompt,
+    parse_procurement_intent,
+)
 
 load_dotenv()
 
@@ -90,9 +95,18 @@ async def run_procurement(request: RunRequest) -> RunResponse:
             app_name=APP_NAME, user_id=user_id, session_id=session_id
         )
 
+    parsed_intent = parse_procurement_intent(request.message)
+    if not parsed_intent.is_valid:
+        return RunResponse(
+            session_id=session_id,
+            response=build_clarification_message(parsed_intent.missing_fields),
+        )
+
+    normalized_prompt = build_structured_procurement_prompt(parsed_intent.intent)
+
     new_message = genai_types.Content(
         role="user",
-        parts=[genai_types.Part(text=request.message)],
+        parts=[genai_types.Part(text=normalized_prompt)],
     )
 
     # Collect all agent response chunks
@@ -130,9 +144,23 @@ async def run_procurement_stream(request: RunRequest) -> StreamingResponse:
             app_name=APP_NAME, user_id=user_id, session_id=session_id
         )
 
+    parsed_intent = parse_procurement_intent(request.message)
+    if not parsed_intent.is_valid:
+        clarification = build_clarification_message(parsed_intent.missing_fields)
+
+        async def clarification_generator() -> AsyncIterator[str]:
+            yield f"data: {clarification}\n\n"
+
+        return StreamingResponse(
+            clarification_generator(),
+            media_type="text/event-stream",
+        )
+
+    normalized_prompt = build_structured_procurement_prompt(parsed_intent.intent)
+
     new_message = genai_types.Content(
         role="user",
-        parts=[genai_types.Part(text=request.message)],
+        parts=[genai_types.Part(text=normalized_prompt)],
     )
 
     async def event_generator() -> AsyncIterator[str]:

--- a/tests/test_intent_tools.py
+++ b/tests/test_intent_tools.py
@@ -1,0 +1,55 @@
+"""Unit tests for structured procurement intent parsing."""
+
+from __future__ import annotations
+
+from tools.intent_tools import (
+    build_clarification_message,
+    build_structured_procurement_prompt,
+    parse_procurement_intent,
+)
+
+
+class TestParseProcurementIntent:
+    def test_parses_quantity_and_product(self):
+        result = parse_procurement_intent("Buy 3 Laptop Pro 15 units")
+        assert result.is_valid
+        assert result.intent is not None
+        assert result.intent.quantity == 3
+        assert result.intent.product == "Laptop Pro 15 units"
+
+    def test_parses_budget_and_currency(self):
+        result = parse_procurement_intent("Buy 10 laptops under 4500 eur")
+        assert result.is_valid
+        assert result.intent is not None
+        assert result.intent.budget == 4500.0
+        assert result.intent.currency == "EUR"
+
+    def test_missing_quantity_returns_clarification_fields(self):
+        result = parse_procurement_intent("Buy laptops from best vendor")
+        assert not result.is_valid
+        assert "quantity" in result.missing_fields
+
+    def test_missing_product_returns_clarification_fields(self):
+        result = parse_procurement_intent("Buy 5")
+        assert not result.is_valid
+        assert "product" in result.missing_fields
+
+    def test_defaults_currency_to_usd(self):
+        result = parse_procurement_intent("Order 2 docking stations")
+        assert result.is_valid
+        assert result.intent is not None
+        assert result.intent.currency == "USD"
+
+
+class TestPromptBuilders:
+    def test_clarification_message_contains_missing_fields(self):
+        message = build_clarification_message(["quantity", "product"])
+        assert "quantity" in message.lower()
+        assert "product" in message.lower()
+
+    def test_structured_prompt_contains_intent_json_marker(self):
+        result = parse_procurement_intent("Buy 4 monitors under 2000 usd")
+        assert result.is_valid
+        prompt = build_structured_procurement_prompt(result.intent)
+        assert "INTENT_JSON:" in prompt
+        assert '"quantity": 4' in prompt

--- a/tools/intent_tools.py
+++ b/tools/intent_tools.py
@@ -1,0 +1,140 @@
+"""Intent tools for structured procurement request extraction.
+
+This module provides deterministic parsing helpers so the runtime can validate
+and normalize procurement requests before invoking the agent pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+_QUANTITY_PATTERN = re.compile(r"\b(?:buy|purchase|order)?\s*(\d+)\s*(?:units?|pcs?|pieces?|x)?\b", re.IGNORECASE)
+_BUDGET_PATTERN = re.compile(
+    r"\b(?:under|below|max|budget(?:\s+of)?|up\s+to)\s*\$?\s*(\d+(?:\.\d+)?)\b",
+    re.IGNORECASE,
+)
+_CURRENCY_PATTERN = re.compile(r"\b(usd|eur|nok|gbp)\b", re.IGNORECASE)
+
+
+class ProcurementIntent(BaseModel):
+    """Normalized procurement intent extracted from user text."""
+
+    product: str = Field(min_length=2)
+    quantity: int = Field(gt=0)
+    budget: float | None = Field(default=None, gt=0)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    raw_message: str
+
+
+class IntentParseResult(BaseModel):
+    """Outcome wrapper for intent extraction."""
+
+    intent: ProcurementIntent | None
+    missing_fields: list[str]
+
+    @property
+    def is_valid(self) -> bool:
+        return self.intent is not None and not self.missing_fields
+
+
+def _extract_quantity(message: str) -> int | None:
+    match = _QUANTITY_PATTERN.search(message)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _extract_product(message: str) -> str | None:
+    text = message.strip()
+    quantity_match = _QUANTITY_PATTERN.search(text)
+    if quantity_match:
+        trailing = text[quantity_match.end():].strip(" ,.")
+        if trailing:
+            split_tokens = re.split(r"\b(from|under|below|max|budget|for|at|with)\b", trailing, maxsplit=1, flags=re.IGNORECASE)
+            candidate = split_tokens[0].strip(" ,.")
+            if len(candidate) >= 2:
+                return candidate
+
+    fallback = re.search(r"\b(?:buy|purchase|order)\s+(.+?)\b(?:from|under|below|max|budget|for|at|with|$)", text, re.IGNORECASE)
+    if fallback:
+        candidate = fallback.group(1).strip(" ,.")
+        if len(candidate) >= 2:
+            return candidate
+
+    return None
+
+
+def _extract_budget(message: str) -> float | None:
+    match = _BUDGET_PATTERN.search(message)
+    if not match:
+        return None
+    return float(match.group(1))
+
+
+def _extract_currency(message: str) -> str:
+    match = _CURRENCY_PATTERN.search(message)
+    if not match:
+        return "USD"
+    return match.group(1).upper()
+
+
+def parse_procurement_intent(message: str) -> IntentParseResult:
+    """Parse a natural language message into a structured procurement intent."""
+    quantity = _extract_quantity(message)
+    product = _extract_product(message)
+    budget = _extract_budget(message)
+    currency = _extract_currency(message)
+
+    missing_fields: list[str] = []
+    if quantity is None:
+        missing_fields.append("quantity")
+    if product is None:
+        missing_fields.append("product")
+
+    if missing_fields:
+        return IntentParseResult(intent=None, missing_fields=missing_fields)
+
+    intent = ProcurementIntent(
+        product=product,
+        quantity=quantity,
+        budget=budget,
+        currency=currency,
+        raw_message=message,
+    )
+    return IntentParseResult(intent=intent, missing_fields=[])
+
+
+def build_clarification_message(missing_fields: list[str]) -> str:
+    """Return a deterministic clarification prompt for missing intent fields."""
+    labels: dict[str, str] = {
+        "product": "product name",
+        "quantity": "quantity",
+        "budget": "budget",
+    }
+    missing = [labels.get(field, field) for field in missing_fields]
+    fields = ", ".join(missing)
+    return (
+        "I need a bit more detail before I can run procurement. "
+        f"Please provide: {fields}. "
+        "Example: 'Buy 3 Laptop Pro 15 units under 5000 USD'."
+    )
+
+
+def build_structured_procurement_prompt(intent: ProcurementIntent) -> str:
+    """Embed normalized intent payload into the message passed to the agents."""
+    payload: dict[str, Any] = {
+        "product": intent.product,
+        "quantity": intent.quantity,
+        "budget": intent.budget,
+        "currency": intent.currency,
+        "raw_message": intent.raw_message,
+    }
+    return (
+        "Use this normalized procurement intent for all calculations and vendor selection.\n"
+        f"INTENT_JSON: {json.dumps(payload, sort_keys=True)}"
+    )


### PR DESCRIPTION
## Summary
Adds typed procurement intent parsing and validation before agent execution.

## Changes
- Added tools/intent_tools.py for parsing and normalization
- Added clarification response when product/quantity are missing
- Wired normalized intent context into run and stream endpoints
- Added tests for parser behavior

## Validation
- pytest tests passed
- ruff checks passed on touched files

Closes #13