### PR TITLE
feat: add JWT authn/authz for procurement endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,11 @@ AURA_PROVIDER_MODE=mock
 # AP2_MANDATE_URL=https://ap2.example/api/mandates
 # AP2_SETTLEMENT_URL=https://ap2.example/api/settlements
 # AP2_API_TOKEN=<optional-token>
+
+# API Authentication (optional)
+# When AUTH_ENABLED=true, /run and /run/stream require a valid JWT bearer token.
+AUTH_ENABLED=false
+AUTH_JWT_SECRET=
+AUTH_JWT_ALGORITHM=HS256
+# Comma-separated roles allowed to execute procurement endpoints
+AUTH_ALLOWED_ROLES=procurement_runner,admin

--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ curl -X POST http://localhost:8080/run \
 
 See [API Reference](docs/API_REFERENCE.md) for full endpoint documentation.
 
+### API Authentication (Optional)
+
+Aura can run with JWT auth enabled for `/run` and `/run/stream`.
+
+```bash
+# .env
+AUTH_ENABLED=true
+AUTH_JWT_SECRET=replace-with-strong-secret
+AUTH_JWT_ALGORITHM=HS256
+AUTH_ALLOWED_ROLES=procurement_runner,admin
+```
+
+When enabled, call endpoints with a bearer token containing at least:
+- `sub` (caller identity)
+- `role` (must be in `AUTH_ALLOWED_ROLES`)
+
+Example request:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Authorization: Bearer <jwt-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Buy 3 Laptop Pro 15 units"}'
+```
+
 ### Streamlit Dashboard
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -14,9 +14,10 @@ import os
 import uuid
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
+import logging
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -30,8 +31,11 @@ from tools.intent_tools import (
     build_structured_procurement_prompt,
     parse_procurement_intent,
 )
+from tools.auth_tools import AuthIdentity, require_procurement_identity
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 # ── ADK wiring ────────────────────────────────────────────────────────────────
 
@@ -81,10 +85,18 @@ async def health() -> dict[str, str]:
 
 
 @app.post("/run", response_model=RunResponse)
-async def run_procurement(request: RunRequest) -> RunResponse:
+async def run_procurement(
+    request: RunRequest,
+    identity: AuthIdentity = Depends(require_procurement_identity),
+) -> RunResponse:
     """Submit a natural language procurement request to the Aura agent pipeline."""
     session_id = request.session_id or str(uuid.uuid4())
-    user_id = request.user_id
+    user_id = request.user_id if request.user_id != "default-user" else identity.subject
+
+    logger.info(
+        "procurement_run_request",
+        extra={"caller": identity.subject, "role": identity.role, "session_id": session_id},
+    )
 
     # Ensure session exists
     existing = await _session_service.get_session(
@@ -103,6 +115,7 @@ async def run_procurement(request: RunRequest) -> RunResponse:
         )
 
     normalized_prompt = build_structured_procurement_prompt(parsed_intent.intent)
+    normalized_prompt = f"{normalized_prompt}\nCALLER_ROLE: {identity.role}\nCALLER_SUBJECT: {identity.subject}"
 
     new_message = genai_types.Content(
         role="user",
@@ -131,10 +144,18 @@ async def run_procurement(request: RunRequest) -> RunResponse:
 
 
 @app.post("/run/stream")
-async def run_procurement_stream(request: RunRequest) -> StreamingResponse:
+async def run_procurement_stream(
+    request: RunRequest,
+    identity: AuthIdentity = Depends(require_procurement_identity),
+) -> StreamingResponse:
     """Stream the agent response token by token (SSE-compatible)."""
     session_id = request.session_id or str(uuid.uuid4())
-    user_id = request.user_id
+    user_id = request.user_id if request.user_id != "default-user" else identity.subject
+
+    logger.info(
+        "procurement_stream_request",
+        extra={"caller": identity.subject, "role": identity.role, "session_id": session_id},
+    )
 
     existing = await _session_service.get_session(
         app_name=APP_NAME, user_id=user_id, session_id=session_id
@@ -157,6 +178,7 @@ async def run_procurement_stream(request: RunRequest) -> StreamingResponse:
         )
 
     normalized_prompt = build_structured_procurement_prompt(parsed_intent.intent)
+    normalized_prompt = f"{normalized_prompt}\nCALLER_ROLE: {identity.role}\nCALLER_SUBJECT: {identity.subject}"
 
     new_message = genai_types.Content(
         role="user",

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,116 @@
+"""Authentication and authorization tests for procurement API endpoints."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+from jose import jwt
+
+import main
+
+
+class _DummySessionService:
+    async def get_session(self, app_name: str, user_id: str, session_id: str):
+        return None
+
+    async def create_session(self, app_name: str, user_id: str, session_id: str):
+        return {"app_name": app_name, "user_id": user_id, "session_id": session_id}
+
+
+class _DummyRunner:
+    async def run_async(self, user_id: str, session_id: str, new_message):
+        event = SimpleNamespace(
+            content=SimpleNamespace(parts=[SimpleNamespace(text="ok")])
+        )
+        yield event
+
+
+def _token(secret: str, role: str, sub: str = "alice") -> str:
+    return jwt.encode({"sub": sub, "role": role}, secret, algorithm="HS256")
+
+
+def test_run_requires_auth_when_enabled(monkeypatch):
+    monkeypatch.setattr(main, "_session_service", _DummySessionService())
+    monkeypatch.setattr(main, "_runner", _DummyRunner())
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("AUTH_ALLOWED_ROLES", "procurement_runner,admin")
+
+    client = TestClient(main.app)
+    response = client.post("/run", json={"message": "Buy 2 laptops"})
+
+    assert response.status_code == 401
+
+
+def test_run_rejects_forbidden_role(monkeypatch):
+    monkeypatch.setattr(main, "_session_service", _DummySessionService())
+    monkeypatch.setattr(main, "_runner", _DummyRunner())
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("AUTH_ALLOWED_ROLES", "procurement_runner,admin")
+
+    token = _token(secret="test-secret", role="viewer")
+    client = TestClient(main.app)
+    response = client.post(
+        "/run",
+        json={"message": "Buy 2 laptops"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_run_allows_authorized_role(monkeypatch):
+    monkeypatch.setattr(main, "_session_service", _DummySessionService())
+    monkeypatch.setattr(main, "_runner", _DummyRunner())
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("AUTH_ALLOWED_ROLES", "procurement_runner,admin")
+
+    token = _token(secret="test-secret", role="procurement_runner")
+    client = TestClient(main.app)
+    response = client.post(
+        "/run",
+        json={"message": "Buy 2 laptops"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "session_id" in body
+    assert body["response"] == "ok"
+
+
+def test_stream_requires_auth_when_enabled(monkeypatch):
+    monkeypatch.setattr(main, "_session_service", _DummySessionService())
+    monkeypatch.setattr(main, "_runner", _DummyRunner())
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret")
+
+    client = TestClient(main.app)
+    response = client.post("/run/stream", json={"message": "Buy 2 laptops"})
+
+    assert response.status_code == 401
+
+
+def test_stream_allows_authorized_role(monkeypatch):
+    monkeypatch.setattr(main, "_session_service", _DummySessionService())
+    monkeypatch.setattr(main, "_runner", _DummyRunner())
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("AUTH_ALLOWED_ROLES", "procurement_runner,admin")
+
+    token = _token(secret="test-secret", role="admin")
+    client = TestClient(main.app)
+
+    with client.stream(
+        "POST",
+        "/run/stream",
+        json={"message": "Buy 2 laptops"},
+        headers={"Authorization": f"Bearer {token}"},
+    ) as response:
+        payload = "".join(chunk.decode("utf-8") for chunk in response.iter_raw())
+
+    assert response.status_code == 200
+    assert "data: ok" in payload

--- a/tools/auth_tools.py
+++ b/tools/auth_tools.py
@@ -1,0 +1,86 @@
+"""Authentication helpers for Aura API endpoints."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from fastapi import HTTPException, Request, status
+from jose import JWTError, jwt
+
+
+@dataclass
+class AuthIdentity:
+    subject: str
+    role: str
+    token_claims: dict
+
+
+def _is_auth_enabled() -> bool:
+    return os.getenv("AUTH_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_bearer_token(request: Request) -> str:
+    header = request.headers.get("Authorization", "")
+    prefix = "Bearer "
+    if not header.startswith(prefix):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid Authorization header.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    token = header[len(prefix):].strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing bearer token.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return token
+
+
+def _decode_identity(token: str) -> AuthIdentity:
+    secret = os.getenv("AUTH_JWT_SECRET", "").strip()
+    algorithm = os.getenv("AUTH_JWT_ALGORITHM", "HS256").strip() or "HS256"
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="AUTH_ENABLED requires AUTH_JWT_SECRET.",
+        )
+
+    try:
+        claims = jwt.decode(token, secret, algorithms=[algorithm], options={"verify_aud": False})
+    except JWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid bearer token.",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    subject = str(claims.get("sub", "")).strip() or "unknown-user"
+
+    role_claim = claims.get("role")
+    if role_claim is None and isinstance(claims.get("roles"), list) and claims["roles"]:
+        role_claim = claims["roles"][0]
+    role = str(role_claim or "").strip()
+
+    return AuthIdentity(subject=subject, role=role, token_claims=claims)
+
+
+def require_procurement_identity(request: Request) -> AuthIdentity:
+    """Return caller identity, enforcing JWT auth when AUTH_ENABLED=true."""
+    if not _is_auth_enabled():
+        return AuthIdentity(subject="anonymous", role="anonymous", token_claims={})
+
+    token = _parse_bearer_token(request)
+    identity = _decode_identity(token)
+
+    allowed_roles_raw = os.getenv("AUTH_ALLOWED_ROLES", "procurement_runner,admin")
+    allowed_roles = {item.strip() for item in allowed_roles_raw.split(",") if item.strip()}
+    if identity.role not in allowed_roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Caller role '{identity.role or '<missing>'}' is not allowed.",
+        )
+
+    return identity


### PR DESCRIPTION
## Summary
Adds optional JWT authentication and role-based authorization for  and .

## Changes
- Added  for JWT validation and role checks
- Protected procurement endpoints with FastAPI dependency
- Propagated caller identity into run context
- Added endpoint auth tests (401/403/200)
- Documented auth env and usage in  and 

## Validation
- pytest tests passed (113)
- ruff checks passed on changed Python files

Closes #18