### PR TITLE
feat: add durable Redis session backend option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,13 @@ AUTH_JWT_SECRET=
 AUTH_JWT_ALGORITHM=HS256
 # Comma-separated roles allowed to execute procurement endpoints
 AUTH_ALLOWED_ROLES=procurement_runner,admin
+
+# Session backend
+# inmemory = default local/dev backend
+# redis = durable backend for multi-instance/runtime persistence
+SESSION_BACKEND=inmemory
+# Required when SESSION_BACKEND=redis
+# REDIS_URL=redis://localhost:6379/0
+# Optional redis session settings
+REDIS_SESSION_KEY_PREFIX=aura:sessions
+SESSION_TTL_SECONDS=0

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ curl -X POST http://localhost:8080/run \
   -d '{"message": "Buy 3 Laptop Pro 15 units"}'
 ```
 
+### Session Backend (In-Memory or Redis)
+
+Aura uses `SESSION_BACKEND` to choose session persistence:
+
+```bash
+# default dev mode
+SESSION_BACKEND=inmemory
+
+# durable mode
+SESSION_BACKEND=redis
+REDIS_URL=redis://localhost:6379/0
+REDIS_SESSION_KEY_PREFIX=aura:sessions
+SESSION_TTL_SECONDS=0
+```
+
+Use Redis mode for multi-instance or restart-resilient deployments.
+
 ### Streamlit Dashboard
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -22,7 +22,6 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from google.adk.runners import Runner
-from google.adk.sessions import InMemorySessionService
 from google.genai import types as genai_types
 
 from agents.architect import architect
@@ -32,6 +31,7 @@ from tools.intent_tools import (
     parse_procurement_intent,
 )
 from tools.auth_tools import AuthIdentity, require_procurement_identity
+from tools.session_tools import build_session_service
 
 load_dotenv()
 
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 # ── ADK wiring ────────────────────────────────────────────────────────────────
 
 APP_NAME = os.getenv("APP_NAME", "aura")
-_session_service = InMemorySessionService()
+_session_service = build_session_service()
 
 _runner = Runner(
     app_name=APP_NAME,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest>=8.3.0
 pytest-asyncio>=0.25.0
 httpx>=0.28.0
 streamlit>=1.40.0
+redis>=5.2.0

--- a/tests/test_session_tools.py
+++ b/tests/test_session_tools.py
@@ -1,0 +1,39 @@
+"""Tests for session backend selection and configuration guards."""
+
+from __future__ import annotations
+
+import pytest
+from google.adk.sessions import InMemorySessionService
+
+from tools.session_tools import RedisSessionService, build_session_service
+
+
+def test_default_session_backend_is_inmemory(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("SESSION_BACKEND", raising=False)
+    service = build_session_service()
+    assert isinstance(service, InMemorySessionService)
+
+
+def test_redis_backend_requires_url(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SESSION_BACKEND", "redis")
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="REDIS_URL"):
+        build_session_service()
+
+
+def test_redis_backend_builds_with_url(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SESSION_BACKEND", "redis")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("REDIS_SESSION_KEY_PREFIX", "aura:test")
+    monkeypatch.setenv("SESSION_TTL_SECONDS", "60")
+
+    service = build_session_service()
+    assert isinstance(service, RedisSessionService)
+
+
+def test_unknown_session_backend_raises(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SESSION_BACKEND", "unsupported")
+
+    with pytest.raises(RuntimeError, match="Unsupported SESSION_BACKEND"):
+        build_session_service()

--- a/tools/session_tools.py
+++ b/tools/session_tools.py
@@ -1,0 +1,144 @@
+"""Session backend selection and durable Redis session service."""
+
+from __future__ import annotations
+
+import copy
+import os
+import time
+import uuid
+from typing import Optional
+
+from google.adk.events import Event
+from google.adk.sessions import BaseSessionService, InMemorySessionService, Session
+from google.adk.sessions.base_session_service import GetSessionConfig, ListSessionsResponse
+
+try:
+    import redis.asyncio as redis
+except Exception:  # pragma: no cover - optional import for redis backend
+    redis = None
+
+
+class RedisSessionService(BaseSessionService):
+    """Redis-backed session service for cross-process persistence."""
+
+    def __init__(self, redis_url: str, key_prefix: str = "aura:sessions", ttl_seconds: int = 0):
+        if redis is None:
+            raise RuntimeError("redis package is required for SESSION_BACKEND=redis")
+        self._redis = redis.from_url(redis_url, decode_responses=True)
+        self._key_prefix = key_prefix
+        self._ttl_seconds = ttl_seconds
+
+    def _session_key(self, app_name: str, user_id: str, session_id: str) -> str:
+        return f"{self._key_prefix}:{app_name}:{user_id}:{session_id}"
+
+    def _session_pattern(self, app_name: str, user_id: Optional[str] = None) -> str:
+        if user_id is None:
+            return f"{self._key_prefix}:{app_name}:*:*"
+        return f"{self._key_prefix}:{app_name}:{user_id}:*"
+
+    async def _persist_session(self, session: Session) -> None:
+        key = self._session_key(session.app_name, session.user_id, session.id)
+        await self._redis.set(key, session.model_dump_json())
+        if self._ttl_seconds > 0:
+            await self._redis.expire(key, self._ttl_seconds)
+
+    async def create_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        state: Optional[dict[str, object]] = None,
+        session_id: Optional[str] = None,
+    ) -> Session:
+        resolved_session_id = session_id.strip() if session_id and session_id.strip() else str(uuid.uuid4())
+        existing = await self.get_session(app_name=app_name, user_id=user_id, session_id=resolved_session_id)
+        if existing is not None:
+            raise ValueError(f"Session with id {resolved_session_id} already exists.")
+
+        session = Session(
+            app_name=app_name,
+            user_id=user_id,
+            id=resolved_session_id,
+            state=state or {},
+            last_update_time=time.time(),
+        )
+        await self._persist_session(session)
+        return copy.deepcopy(session)
+
+    async def get_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        config: Optional[GetSessionConfig] = None,
+    ) -> Optional[Session]:
+        key = self._session_key(app_name, user_id, session_id)
+        raw = await self._redis.get(key)
+        if raw is None:
+            return None
+
+        session = Session.model_validate_json(raw)
+        copied_session = copy.deepcopy(session)
+
+        if config:
+            if config.num_recent_events:
+                copied_session.events = copied_session.events[-config.num_recent_events :]
+            if config.after_timestamp:
+                copied_session.events = [
+                    event for event in copied_session.events if event.timestamp >= config.after_timestamp
+                ]
+
+        return copied_session
+
+    async def list_sessions(
+        self, *, app_name: str, user_id: Optional[str] = None
+    ) -> ListSessionsResponse:
+        sessions: list[Session] = []
+        async for key in self._redis.scan_iter(match=self._session_pattern(app_name, user_id)):
+            raw = await self._redis.get(key)
+            if raw is None:
+                continue
+            session = Session.model_validate_json(raw)
+            copied = copy.deepcopy(session)
+            copied.events = []
+            sessions.append(copied)
+
+        return ListSessionsResponse(sessions=sessions)
+
+    async def delete_session(self, *, app_name: str, user_id: str, session_id: str) -> None:
+        key = self._session_key(app_name, user_id, session_id)
+        await self._redis.delete(key)
+
+    async def append_event(self, session: Session, event: Event) -> Event:
+        if event.partial:
+            return event
+
+        await super().append_event(session=session, event=event)
+        session.last_update_time = event.timestamp
+        await self._persist_session(session)
+        return event
+
+
+def build_session_service() -> BaseSessionService:
+    """Create session service based on SESSION_BACKEND environment setting."""
+    backend = os.getenv("SESSION_BACKEND", "inmemory").strip().lower()
+    if backend == "inmemory":
+        return InMemorySessionService()
+
+    if backend == "redis":
+        redis_url = os.getenv("REDIS_URL", "").strip()
+        if not redis_url:
+            raise RuntimeError("SESSION_BACKEND=redis requires REDIS_URL to be set.")
+
+        key_prefix = os.getenv("REDIS_SESSION_KEY_PREFIX", "aura:sessions").strip() or "aura:sessions"
+        ttl_seconds = int(os.getenv("SESSION_TTL_SECONDS", "0").strip() or "0")
+        return RedisSessionService(
+            redis_url=redis_url,
+            key_prefix=key_prefix,
+            ttl_seconds=ttl_seconds,
+        )
+
+    raise RuntimeError(
+        f"Unsupported SESSION_BACKEND='{backend}'. Expected 'inmemory' or 'redis'."
+    )


### PR DESCRIPTION
## Summary
Adds pluggable session backend selection with Redis durability support and in-memory fallback.

## Changes
- Added  with  and 
- Switched  to use backend builder instead of hardcoded in-memory service
- Added  and Redis env configuration
- Added session backend tests
- Added redis dependency

## Validation
- pytest tests passed (117)
- ruff checks passed on touched Python files

Closes #20