### PR TITLE
feat: add provider reliability controls and idempotency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,12 @@ SESSION_BACKEND=inmemory
 # Optional redis session settings
 REDIS_SESSION_KEY_PREFIX=aura:sessions
 SESSION_TTL_SECONDS=0
+
+# Reliability controls for real providers
+# Number of attempts for transient HTTP failures
+HTTP_RETRY_ATTEMPTS=3
+# Base delay (seconds) for exponential backoff between retries
+HTTP_RETRY_BACKOFF_SECONDS=0.2
+# Circuit breaker settings
+CIRCUIT_BREAKER_FAILURE_THRESHOLD=3
+CIRCUIT_BREAKER_RESET_SECONDS=30

--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ SESSION_TTL_SECONDS=0
 
 Use Redis mode for multi-instance or restart-resilient deployments.
 
+### Reliability Controls (Real Provider Mode)
+
+In `AURA_PROVIDER_MODE=real`, Aura applies retries, exponential backoff,
+and a circuit breaker to UCP/BMS/AP2 HTTP calls.
+
+```bash
+HTTP_RETRY_ATTEMPTS=3
+HTTP_RETRY_BACKOFF_SECONDS=0.2
+CIRCUIT_BREAKER_FAILURE_THRESHOLD=3
+CIRCUIT_BREAKER_RESET_SECONDS=30
+```
+
+AP2 settlement requests also include a deterministic `Idempotency-Key`
+derived from mandate data to reduce duplicate settlement risk on retries.
+
 ### Streamlit Dashboard
 
 ```bash

--- a/tests/test_ap2_tools.py
+++ b/tests/test_ap2_tools.py
@@ -11,7 +11,11 @@ Branch: test/closer-unit
 import re
 import uuid
 import pytest
-from tools.ap2_tools import generate_intent_mandate, settle_cart_mandate
+from tools.ap2_tools import (
+    build_settlement_idempotency_key,
+    generate_intent_mandate,
+    settle_cart_mandate,
+)
 
 
 # ─────────────────────────────────────────────
@@ -153,3 +157,11 @@ class TestSettleCartMandate:
         bad["proof"] = {"type": "ecdsa-p256-signature", "value": "", "created": 0}
         with pytest.raises(ValueError, match="proof"):
             settle_cart_mandate(bad)
+
+
+class TestIdempotency:
+    def test_settlement_idempotency_key_is_deterministic(self, valid_mandate):
+        key1 = build_settlement_idempotency_key(valid_mandate)
+        key2 = build_settlement_idempotency_key(valid_mandate)
+        assert key1 == key2
+        assert len(key1) == 64

--- a/tests/test_reliability_tools.py
+++ b/tests/test_reliability_tools.py
@@ -1,0 +1,52 @@
+"""Tests for retry and circuit breaker behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.reliability_tools import CircuitBreaker, CircuitOpenError, execute_with_retries
+
+
+def test_execute_with_retries_eventually_succeeds(monkeypatch: pytest.MonkeyPatch):
+    attempts: dict[str, int] = {"count": 0}
+
+    def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise ValueError("transient")
+        return "ok"
+
+    monkeypatch.setattr("tools.reliability_tools.time.sleep", lambda _: None)
+
+    result = execute_with_retries(
+        flaky,
+        attempts=3,
+        base_backoff_seconds=0.01,
+        circuit_breaker=CircuitBreaker(failure_threshold=10, reset_timeout_seconds=1),
+        retryable_exceptions=(ValueError,),
+    )
+
+    assert result == "ok"
+    assert attempts["count"] == 3
+
+
+def test_execute_with_retries_raises_after_max_attempts(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("tools.reliability_tools.time.sleep", lambda _: None)
+
+    with pytest.raises(ValueError, match="boom"):
+        execute_with_retries(
+            lambda: (_ for _ in ()).throw(ValueError("boom")),
+            attempts=2,
+            base_backoff_seconds=0.01,
+            circuit_breaker=CircuitBreaker(failure_threshold=10, reset_timeout_seconds=1),
+            retryable_exceptions=(ValueError,),
+        )
+
+
+def test_circuit_breaker_opens_after_threshold():
+    breaker = CircuitBreaker(failure_threshold=2, reset_timeout_seconds=10)
+    breaker.record_failure()
+    breaker.record_failure()
+
+    with pytest.raises(CircuitOpenError):
+        breaker.before_call()

--- a/tools/ap2_tools.py
+++ b/tools/ap2_tools.py
@@ -19,6 +19,8 @@ from typing import Any, Protocol
 
 import httpx
 
+from tools.reliability_tools import CircuitBreaker, CircuitOpenError, execute_with_retries
+
 
 _COMPLIANCE_HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
@@ -107,6 +109,12 @@ class HttpAp2Provider:
         self.settlement_endpoint = settlement_endpoint
         self.api_token = api_token
         self.timeout_seconds = timeout_seconds
+        self.retry_attempts = int(os.getenv("HTTP_RETRY_ATTEMPTS", "3"))
+        self.retry_backoff_seconds = float(os.getenv("HTTP_RETRY_BACKOFF_SECONDS", "0.2"))
+        self._circuit_breaker = CircuitBreaker(
+            failure_threshold=int(os.getenv("CIRCUIT_BREAKER_FAILURE_THRESHOLD", "3")),
+            reset_timeout_seconds=float(os.getenv("CIRCUIT_BREAKER_RESET_SECONDS", "30")),
+        )
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Content-Type": "application/json"}
@@ -130,7 +138,7 @@ class HttpAp2Provider:
             "compliance_hash": compliance_hash,
         }
 
-        try:
+        def _request() -> Any:
             with httpx.Client(timeout=self.timeout_seconds) as client:
                 response = client.post(
                     self.mandate_endpoint,
@@ -138,7 +146,20 @@ class HttpAp2Provider:
                     headers=self._headers(),
                 )
                 response.raise_for_status()
-                mandate = response.json()
+                return response.json()
+
+        try:
+            mandate = execute_with_retries(
+                _request,
+                attempts=self.retry_attempts,
+                base_backoff_seconds=self.retry_backoff_seconds,
+                circuit_breaker=self._circuit_breaker,
+                retryable_exceptions=(httpx.HTTPError,),
+            )
+        except CircuitOpenError as exc:
+            raise RuntimeError(
+                "AP2 circuit is open due to repeated failures. Try again later."
+            ) from exc
         except httpx.HTTPError as exc:
             raise RuntimeError(
                 "AP2 mandate generation failed. Verify AP2_MANDATE_URL and credentials."
@@ -149,15 +170,31 @@ class HttpAp2Provider:
         return mandate
 
     def settle_cart_mandate(self, mandate: dict[str, Any]) -> dict[str, Any]:
-        try:
+        headers = self._headers()
+        headers["Idempotency-Key"] = build_settlement_idempotency_key(mandate)
+
+        def _request() -> Any:
             with httpx.Client(timeout=self.timeout_seconds) as client:
                 response = client.post(
                     self.settlement_endpoint,
                     json={"mandate": mandate},
-                    headers=self._headers(),
+                    headers=headers,
                 )
                 response.raise_for_status()
-                result = response.json()
+                return response.json()
+
+        try:
+            result = execute_with_retries(
+                _request,
+                attempts=self.retry_attempts,
+                base_backoff_seconds=self.retry_backoff_seconds,
+                circuit_breaker=self._circuit_breaker,
+                retryable_exceptions=(httpx.HTTPError,),
+            )
+        except CircuitOpenError as exc:
+            raise RuntimeError(
+                "AP2 circuit is open due to repeated failures. Try again later."
+            ) from exc
         except httpx.HTTPError as exc:
             raise RuntimeError(
                 "AP2 settlement request failed. Verify AP2_SETTLEMENT_URL and credentials."
@@ -191,6 +228,15 @@ def _get_ap2_provider() -> Ap2Provider:
     raise RuntimeError(
         f"Unsupported AURA_PROVIDER_MODE='{mode}'. Expected 'mock' or 'real'."
     )
+
+
+def build_settlement_idempotency_key(mandate: dict[str, Any]) -> str:
+    """Build a deterministic idempotency key for settlement requests."""
+    mandate_id = str(mandate.get("id", ""))
+    constraints = mandate.get("constraints", {}) if isinstance(mandate, dict) else {}
+    compliance_hash = str(constraints.get("compliance_hash", ""))
+    raw = f"{mandate_id}:{compliance_hash}".encode()
+    return hashlib.sha256(raw).hexdigest()
 
 
 def generate_intent_mandate(

--- a/tools/compliance_tools.py
+++ b/tools/compliance_tools.py
@@ -16,6 +16,8 @@ from typing import Any, Protocol
 
 import httpx
 
+from tools.reliability_tools import CircuitBreaker, CircuitOpenError, execute_with_retries
+
 # AML blacklist — sourced from BMS compliance database
 _BLACKLISTED_VENDORS = frozenset({"ShadowHardware", "shadowhardware"})
 _COMPLIANCE_HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
@@ -58,13 +60,19 @@ class BmsComplianceProvider:
         self.endpoint = endpoint
         self.api_token = api_token
         self.timeout_seconds = timeout_seconds
+        self.retry_attempts = int(os.getenv("HTTP_RETRY_ATTEMPTS", "3"))
+        self.retry_backoff_seconds = float(os.getenv("HTTP_RETRY_BACKOFF_SECONDS", "0.2"))
+        self._circuit_breaker = CircuitBreaker(
+            failure_threshold=int(os.getenv("CIRCUIT_BREAKER_FAILURE_THRESHOLD", "3")),
+            reset_timeout_seconds=float(os.getenv("CIRCUIT_BREAKER_RESET_SECONDS", "30")),
+        )
 
     def verify_vendor_compliance(self, vendor_name: str) -> dict[str, Any]:
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self.api_token:
             headers["Authorization"] = f"Bearer {self.api_token}"
 
-        try:
+        def _request() -> Any:
             with httpx.Client(timeout=self.timeout_seconds) as client:
                 response = client.post(
                     self.endpoint,
@@ -72,7 +80,20 @@ class BmsComplianceProvider:
                     headers=headers,
                 )
                 response.raise_for_status()
-                payload = response.json()
+                return response.json()
+
+        try:
+            payload = execute_with_retries(
+                _request,
+                attempts=self.retry_attempts,
+                base_backoff_seconds=self.retry_backoff_seconds,
+                circuit_breaker=self._circuit_breaker,
+                retryable_exceptions=(httpx.HTTPError,),
+            )
+        except CircuitOpenError as exc:
+            raise RuntimeError(
+                "BMS compliance circuit is open due to repeated failures. Try again later."
+            ) from exc
         except httpx.HTTPError as exc:
             raise RuntimeError(
                 "BMS compliance request failed. Verify BMS_COMPLIANCE_URL and credentials."

--- a/tools/reliability_tools.py
+++ b/tools/reliability_tools.py
@@ -1,0 +1,76 @@
+"""Reliability primitives: retry policy and in-process circuit breaker."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+class CircuitOpenError(RuntimeError):
+    """Raised when a circuit breaker is open and call execution is blocked."""
+
+
+@dataclass
+class CircuitBreaker:
+    """Simple in-process circuit breaker with time-based reset."""
+
+    failure_threshold: int = 3
+    reset_timeout_seconds: float = 30.0
+    failure_count: int = 0
+    opened_at: float | None = None
+
+    def before_call(self) -> None:
+        if self.opened_at is None:
+            return
+        now = time.time()
+        if now - self.opened_at >= self.reset_timeout_seconds:
+            self.failure_count = 0
+            self.opened_at = None
+            return
+        raise CircuitOpenError("Circuit is open. Skipping downstream call.")
+
+    def record_success(self) -> None:
+        self.failure_count = 0
+        self.opened_at = None
+
+    def record_failure(self) -> None:
+        self.failure_count += 1
+        if self.failure_count >= self.failure_threshold:
+            self.opened_at = time.time()
+
+
+def execute_with_retries(
+    operation: Callable[[], T],
+    *,
+    attempts: int,
+    base_backoff_seconds: float,
+    circuit_breaker: CircuitBreaker,
+    retryable_exceptions: tuple[type[Exception], ...],
+) -> T:
+    """Execute callable with retry + backoff + circuit breaker semantics."""
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    last_error: Exception | None = None
+
+    for attempt in range(1, attempts + 1):
+        circuit_breaker.before_call()
+        try:
+            result = operation()
+            circuit_breaker.record_success()
+            return result
+        except retryable_exceptions as exc:
+            last_error = exc
+            circuit_breaker.record_failure()
+            if attempt >= attempts:
+                break
+
+            sleep_seconds = base_backoff_seconds * (2 ** (attempt - 1))
+            if sleep_seconds > 0:
+                time.sleep(sleep_seconds)
+
+    assert last_error is not None
+    raise last_error

--- a/tools/ucp_tools.py
+++ b/tools/ucp_tools.py
@@ -15,6 +15,8 @@ from typing import Any, Protocol
 
 import httpx
 
+from tools.reliability_tools import CircuitBreaker, CircuitOpenError, execute_with_retries
+
 
 @dataclass
 class VendorEndpoint:
@@ -87,13 +89,32 @@ class HttpUcpProvider:
     def __init__(self, discovery_url: str, timeout_seconds: float = 10.0) -> None:
         self.discovery_url = discovery_url
         self.timeout_seconds = timeout_seconds
+        self.retry_attempts = int(os.getenv("HTTP_RETRY_ATTEMPTS", "3"))
+        self.retry_backoff_seconds = float(os.getenv("HTTP_RETRY_BACKOFF_SECONDS", "0.2"))
+        self._circuit_breaker = CircuitBreaker(
+            failure_threshold=int(os.getenv("CIRCUIT_BREAKER_FAILURE_THRESHOLD", "3")),
+            reset_timeout_seconds=float(os.getenv("CIRCUIT_BREAKER_RESET_SECONDS", "30")),
+        )
 
     def discover_vendors(self, query: str) -> list[dict[str, Any]]:
-        try:
+        def _request() -> Any:
             with httpx.Client(timeout=self.timeout_seconds) as client:
                 response = client.get(self.discovery_url, params={"q": query})
                 response.raise_for_status()
-                payload = response.json()
+                return response.json()
+
+        try:
+            payload = execute_with_retries(
+                _request,
+                attempts=self.retry_attempts,
+                base_backoff_seconds=self.retry_backoff_seconds,
+                circuit_breaker=self._circuit_breaker,
+                retryable_exceptions=(httpx.HTTPError,),
+            )
+        except CircuitOpenError as exc:
+            raise RuntimeError(
+                "UCP provider circuit is open due to repeated failures. Try again later."
+            ) from exc
         except httpx.HTTPError as exc:
             raise RuntimeError(
                 "UCP provider request failed. Verify UCP_DISCOVERY_URL and network connectivity."


### PR DESCRIPTION
## Summary
Adds reliability controls for real provider integrations and AP2 idempotency protection.

## Changes
- Added shared retry + circuit breaker utility
- Applied retries/backoff/circuit breaker to UCP/BMS/AP2 HTTP providers
- Added deterministic AP2 settlement idempotency key generation
- Added reliability tests and updated AP2 tests
- Documented reliability env configuration

## Validation
- pytest tests passed (121)
- ruff checks passed on touched files

Closes #22