### PR TITLE
feat: Policy Engine — three-stage governance rules for procurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,53 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [feat/policy-engine] — Unreleased
+
+> Policy Engine feature branch (#15). Adds three-stage governance rules for procurement.
+
+### Added
+
+#### Policy Engine (`tools/`)
+- `tools/policy_store.py` — `PolicyStore` singleton with 6 default rules (SPENDING_LIMIT, GEO_RESTRICTION, CATEGORY_ALLOWLIST, APPROVAL_THRESHOLD, CERTIFICATION_REQUIRED, RATE_LIMIT); atomic JSON persistence to `tmp/policies.json`; `ReviewStore` for human-in-the-loop payment review queue
+- `tools/policy_tools.py` — Three evaluation functions consumed by agents:
+  - `evaluate_procurement_policy(request)` — pre-flight gate (category, spending, rate limits)
+  - `evaluate_vendor_policy(vendor, amount)` — vendor gate (geo-restriction, certifications, approval thresholds)
+  - `evaluate_payment_policy(mandate, user_id)` — payment gate (approval thresholds, daily spend limits)
+  - `RateLimitStore` — sliding-window per-user rate limiting (in-memory)
+  - `DailySpendStore` — per-user daily spend accumulation (in-memory)
+
+#### Governor Agent (`agents/`)
+- `agents/governor.py` — New pre-flight `LlmAgent`; inserted first in the pipeline before Scout; outputs POLICY_CLEAR / POLICY_WARNINGS / POLICY_REVIEW_REQUIRED / POLICY_BLOCKED
+
+#### Pipeline Changes
+- `agents/architect.py` — Updated pipeline: `Governor → Scout → Sentinel → Closer` (previously `Scout → Sentinel → Closer`)
+- `agents/sentinel.py` — Added `evaluate_vendor_policy` tool; now runs both BMS compliance check AND vendor policy check per vendor
+- `agents/closer.py` — Added `evaluate_payment_policy` tool; checks `governor_results` and `sentinel_results` for policy/compliance blocks before any payment settlement
+
+#### Policy Management REST API (`main.py`)
+- `GET /policies` — list all policy rules
+- `POST /policies` — create rule (requires `X-Admin-Token` header)
+- `GET /policies/{rule_id}` — get single rule
+- `PUT /policies/{rule_id}` — partial update (requires `X-Admin-Token`)
+- `DELETE /policies/{rule_id}` — delete rule, returns 204 (requires `X-Admin-Token`)
+- `GET /reviews` — list pending payment reviews
+- `POST /reviews/{id}/approve` — approve a review (requires `X-Admin-Token`)
+- `POST /reviews/{id}/reject` — reject a review (requires `X-Admin-Token`)
+
+#### Kubernetes (`kagent.yaml`)
+- `aura-admin-token` Kubernetes Secret manifest for `AURA_ADMIN_TOKEN`
+- Governor Agent CRD with `evaluate_procurement_policy` MCP tool
+- All agents (Scout, Sentinel, Closer, Architect) updated with `AURA_ADMIN_TOKEN` env var
+- Sentinel and Closer updated with new policy tool registrations
+
+#### Tests (`tests/`)
+- `tests/test_policy_tools.py` — 27 new unit tests covering all 6 rule types, rate limiting, daily spend, snapshot hashing, and disabled-rule bypass
+
+#### Documentation
+- `docs/AGENT_FLOW.md` — Rewritten with three Mermaid sequence diagrams: Happy Path, Policy Block (Governor halts pre-flight), Compliance Block (Sentinel → Closer aborts)
+
+---
+
 ## [0.1.0-hackathon] — 2026-03-11
 
 > Hackathon prototype delivered at **Google AI Agent Labs Oslo 2026 — Team 6**.

--- a/agents/architect.py
+++ b/agents/architect.py
@@ -10,15 +10,16 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent, SequentialAgent
 
+from agents.governor import governor
 from agents.scout import scout
 from agents.sentinel import sentinel
 from agents.closer import closer
 
-# The pipeline: Scout discovers → Sentinel vets → Closer settles
+# The pipeline: Governor gates → Scout discovers → Sentinel vets → Closer settles
 _pipeline = SequentialAgent(
     name="AuraPipeline",
-    description="Sequential procurement pipeline: discovery → compliance → settlement.",
-    sub_agents=[scout, sentinel, closer],
+    description="Sequential procurement pipeline: policy-gate → discovery → compliance → settlement.",
+    sub_agents=[governor, scout, sentinel, closer],
 )
 
 architect = LlmAgent(
@@ -26,28 +27,29 @@ architect = LlmAgent(
     model="gemini-2.0-flash",
     description=(
         "Root orchestrator of the Aura autonomous procurement system. "
-        "Parses enterprise procurement intent and coordinates the multi-agent pipeline."
+        "Parses enterprise procurement intent and coordinates the four-stage multi-agent pipeline."
     ),
     instruction="""You are Architect, the root orchestrator of Project Aura — 
 Autonomous Reliable Agentic Commerce.
 
-Aura automates B2B procurement with built-in compliance. Your pipeline:
-  1. Scout   → discovers vendors via UCP protocol
-  2. Sentinel → verifies KYC/AML compliance via Core Banking
-  3. Closer  → settles payment via AP2 protocol
+Aura automates B2B procurement with built-in policy enforcement and compliance. Your pipeline:
+  1. Governor → pre-flight policy gate (category, spending limits, rate limits)
+  2. Scout    → discovers vendors via UCP protocol
+  3. Sentinel → verifies KYC/AML compliance and vendor policy via Core Banking
+  4. Closer   → settles payment via AP2 protocol (blocked if any gate failed)
 
 When the user submits a procurement request:
 0. If an INTENT_JSON payload is present in the message context, treat it as the source of truth
     for product, quantity, budget, and currency.
 1. Acknowledge the request and clarify any missing details (product, quantity, budget).
-2. Hand off to the AuraPipeline sub-agent to execute Scout → Sentinel → Closer.
+2. Hand off to the AuraPipeline sub-agent to execute Governor → Scout → Sentinel → Closer.
 3. Summarise the final outcome for the user:
    - If successful: vendor chosen, compliance status, settlement ID, amount paid.
-   - If blocked: which vendor failed compliance and why, what the user should do next.
+   - If POLICY_BLOCKED by Governor: explain which policy rules were violated.
+   - If blocked by Sentinel: which vendor failed compliance/policy and why.
+   - If PAYMENT_ABORTED by Closer: payment policy reason and what the user should do next.
 
-You are the user's trusted agent. Always prioritise compliance — never allow a 
-transaction to proceed if the Sentinel has flagged a compliance issue.
-
+You are the user's trusted agent. Always prioritise policy compliance and financial safety.
 Respond in clear, professional language suitable for an enterprise procurement context.
 """,
     sub_agents=[_pipeline],

--- a/agents/closer.py
+++ b/agents/closer.py
@@ -12,38 +12,59 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 
 from tools.ap2_tools import generate_intent_mandate, settle_cart_mandate
+from tools.policy_tools import evaluate_payment_policy
 
 closer = LlmAgent(
     name="Closer",
     model="gemini-2.0-flash",
     description=(
         "Handles secure payment via Agent Payments Protocol v2 (AP2). "
-        "Generates an Intent Mandate and settles the transaction when compliance is confirmed."
+        "Generates an Intent Mandate and settles the transaction when compliance "
+        "and payment policy are both satisfied."
     ),
     instruction="""You are the Closer agent in the Aura procurement system.
 
 Your job is to complete the purchase using the AP2 payment protocol.
 
-PREREQUISITE CHECK — Before anything else:
-- Read the Sentinel's JSON results from context (`sentinel_results`).
-- If `sentinel_results.blocked == true`, immediately output:
-    "PAYMENT_ABORTED: Compliance check failed. No transaction initiated."
-    and stop. Do NOT call any payment tools.
+PREREQUISITE CHECK — Before anything else, read session context:
 
-If compliance was approved, proceed:
+1. If `sentinel_results.blocked == true`:
+   Output: "PAYMENT_ABORTED: Compliance check failed. No transaction initiated."
+   STOP — do NOT call any payment tools.
+
+2. If governor_results contains "POLICY_BLOCKED":
+   Output: "PAYMENT_ABORTED: Pre-flight policy check failed. No transaction initiated."
+   State the policy violation reason. STOP — do NOT call any payment tools.
+
+3. If the Sentinel output contains "COMPLIANCE_BLOCKED" or "POLICY_BLOCKED":
+   Output: "PAYMENT_ABORTED: Vendor compliance or policy check failed. No transaction initiated."
+   STOP — do NOT call any payment tools.
+
+If all checks are clear, proceed:
 1. Identify the best vendor from the Scout results (lowest price, approved by Sentinel).
 2. Extract the compliance_hash for that vendor from `sentinel_results.approved_vendors`.
-     If no compliance_hash exists for the selected vendor, abort with PAYMENT_ABORTED.
-3. Calculate the total amount (unit_price * quantity requested, max 5000 USD).
-4. Call generate_intent_mandate(vendor_id, vendor_name, amount, currency, compliance_hash).
-5. Review the generated mandate — confirm it has a valid proof signature.
-6. Call settle_cart_mandate(mandate) to submit to the AP2 gateway.
-7. Report the settlement result including settlement_id and confirmed amount.
+   If no compliance_hash exists for the selected vendor, abort with PAYMENT_ABORTED.
+3. Extract the quantity from the user's original request (default to 1 if not stated).
+4. Calculate the total amount (unit_price * quantity requested, max 5000 USD).
+5. Call evaluate_payment_policy with a dict containing:
+   - amount_usd: the calculated amount
+   and user_id from the session context (default "unknown" if not available).
+6. Evaluate the payment policy decision:
+   - If decision is "BLOCK": output "PAYMENT_ABORTED: Payment policy blocked. <reason>" and STOP.
+   - If decision is "REVIEW": output "PAYMENT_PENDING_REVIEW: <reason>" and STOP.
+     Do NOT call AP2 settlement tools — the payment must be approved in the review queue first.
+   - If decision is "WARN": note the warning and continue.
+   - If decision is "ALLOW": continue to settlement.
+7. Call generate_intent_mandate(vendor_id, vendor_name, amount, currency, compliance_hash).
+8. Review the generated mandate — confirm it has a valid proof signature.
+9. Call settle_cart_mandate(mandate) to submit to the AP2 gateway.
+10. Report the settlement result including settlement_id and confirmed amount.
 
 Always present the final outcome clearly:
 - SETTLEMENT_CONFIRMED with settlement_id and amount
-- or PAYMENT_ABORTED with reason
+- PAYMENT_PENDING_REVIEW with reason (human approval required before settlement)
+- PAYMENT_ABORTED with reason (hard block — no payment initiated)
 """,
-    tools=[generate_intent_mandate, settle_cart_mandate],
+    tools=[generate_intent_mandate, settle_cart_mandate, evaluate_payment_policy],
     output_key="closer_results",
 )

--- a/agents/governor.py
+++ b/agents/governor.py
@@ -1,0 +1,51 @@
+"""
+Governor Agent — pre-flight policy gate for the Aura procurement pipeline.
+
+The Governor runs FIRST in the SequentialAgent pipeline (before Scout).
+It evaluates the procurement request against the Policy Engine rules and
+writes its decision to session_state["governor_results"].
+"""
+
+from __future__ import annotations
+
+from google.adk.agents import LlmAgent
+
+from tools.policy_tools import evaluate_procurement_policy
+
+governor = LlmAgent(
+    name="Governor",
+    model="gemini-2.0-flash",
+    description=(
+        "Pre-flight policy gate. Evaluates every procurement request against "
+        "the organisation's procurement rules before any vendor discovery begins."
+    ),
+    instruction="""You are the Governor agent in the Aura procurement system.
+
+Your job is to evaluate procurement requests against the organisation's policy rules
+BEFORE any vendor is contacted.
+
+Steps:
+1. Extract the following fields from the user's request:
+   - category: the product/service category (e.g. "hardware", "saas")
+   - amount_usd: the estimated total spend in US dollars
+   - user_id: the requesting user or session identifier (default "unknown" if not provided)
+
+2. Call evaluate_procurement_policy with:
+   {"category": <category>, "amount_usd": <amount_usd>, "user_id": <user_id>}
+
+3. Interpret the result and output ONE of:
+   - POLICY_CLEAR — decision is ALLOW, no violations
+   - POLICY_WARNINGS — decision is WARN, list each warning
+   - POLICY_REVIEW_REQUIRED — decision is REVIEW, list reasons and add to review queue
+   - POLICY_BLOCKED — decision is BLOCK, state each violation and STOP
+
+4. Always include the snapshot_hash from the decision in your output so downstream
+   agents can verify the rule set did not change between stages.
+
+Examples:
+  POLICY_CLEAR (snapshot: a1b2c3d4e5f6g7h8) — all rules passed
+  POLICY_BLOCKED: Category 'weapons' not allowed. Transaction $12,000 exceeds limit. (snapshot: a1b2c3d4e5f6g7h8)
+""",
+    tools=[evaluate_procurement_policy],
+    output_key="governor_results",
+)

--- a/agents/sentinel.py
+++ b/agents/sentinel.py
@@ -12,19 +12,38 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 
 from tools.compliance_tools import evaluate_vendors_compliance, verify_vendor_compliance
+from tools.policy_tools import evaluate_vendor_policy
 
 sentinel = LlmAgent(
     name="Sentinel",
     model="gemini-2.0-flash",
     description=(
-        "Executes KYC/AML compliance checks on vendors via the Core Banking System. "
-        "Blocks any vendor flagged in the AML blacklist and emits ComplianceHash for approved vendors."
+        "Executes KYC/AML compliance checks and vendor policy evaluation. "
+        "Blocks any vendor flagged in the AML blacklist or blocked by policy rules."
     ),
     instruction="""You are the Sentinel agent in the Aura procurement system.
 
-Your job is to run EVERY vendor from the Scout's results through the compliance database.
+Your job is to run EVERY vendor from the Scout's results through BOTH the compliance
+database AND the policy engine.
 
-You MUST produce a strict JSON object as your final output with this exact schema:
+Steps:
+1. Read the Scout vendor list from context.
+2. For each vendor, call BOTH:
+   a. verify_vendor_compliance(vendor_name) — KYC/AML check via Core Banking System
+   b. evaluate_vendor_policy(vendor_dict, requested_amount) — policy engine check
+
+3. A vendor is rejected if either check fails:
+   - BMS returns REJECTED status → COMPLIANCE_BLOCKED
+   - Policy returns BLOCK decision → POLICY_BLOCKED
+
+4. Output ONE of:
+   - SENTINEL_APPROVED — all vendors passed (or at least one approved vendor remains)
+     Include: list of approved vendors with compliance_hash values
+   - COMPLIANCE_BLOCKED — BMS rejected all viable vendors (AML blacklist)
+   - POLICY_BLOCKED — policy engine blocked all viable vendors (geo-restriction etc.)
+   - SENTINEL_REVIEW_REQUIRED — policy returned REVIEW for some vendors
+
+You MUST always output a JSON object with this schema:
 {
     "blocked": <bool>,
     "approved_vendors": [{"vendor_name": "...", "compliance_hash": "..."}],
@@ -32,18 +51,9 @@ You MUST produce a strict JSON object as your final output with this exact schem
     "reason_codes": ["..."]
 }
 
-Steps:
-1. Read the Scout vendor list from context.
-2. Call evaluate_vendors_compliance(vendors) using the full vendor list.
-3. Return the result unchanged as the final JSON response.
-
-Fallback behavior: if structured vendor list cannot be parsed from context,
-run verify_vendor_compliance(vendor_name) manually for each vendor you can identify,
-then still output the final strict JSON schema above.
-
-IMPORTANT: If ShadowHardware or any blacklisted vendor appears, you MUST block the entire
-transaction by setting "blocked": true. The safety of the financial system depends on this.
+IMPORTANT: If ShadowHardware or any blacklisted vendor appears, you MUST block the
+transaction by setting "blocked": true in the output.
 """,
-        tools=[evaluate_vendors_compliance, verify_vendor_compliance],
+    tools=[evaluate_vendors_compliance, verify_vendor_compliance, evaluate_vendor_policy],
     output_key="sentinel_results",
 )

--- a/docs/AGENT_FLOW.md
+++ b/docs/AGENT_FLOW.md
@@ -2,11 +2,160 @@
 
 ## Overview
 
-This document shows the detailed message flow through the Aura multi-agent pipeline for two key scenarios:
-1. **Happy Path** — legitimate vendor, compliance approved, payment settled
-2. **Blocked Path** — blacklisted vendor detected, pipeline halted before payment
+This document shows the detailed message flow through the Aura multi-agent pipeline for three key scenarios:
+
+1. **Happy Path** — request clears all policy gates, vendor approved, payment settled
+2. **Policy Block** — Governor halts the pipeline at the pre-flight stage (geo-restriction)
+3. **Compliance Block** — Sentinel detects AML blacklist, Closer aborts payment
+
+The pipeline runs in strict sequence: **Governor → Scout → Sentinel → Closer**.  
+The Governor is the pre-flight gate added by the Policy Engine feature (issue #15).
 
 ---
+
+## Scenario 1 — Happy Path (Policy Clear → Settlement)
+
+```mermaid
+sequenceDiagram
+    actor User as 👤 Enterprise User
+    participant Architect as 🏛️ Architect
+    participant Governor as ⚖️ Governor
+    participant PolicyEngine as 📋 Policy Engine
+    participant Scout as 🔭 Scout
+    participant UCP as 🌐 UCP Network
+    participant Sentinel as 🛡️ Sentinel
+    participant BMS as 🏦 BMS Compliance DB
+    participant Closer as 💳 Closer
+    participant AP2 as 🔐 AP2 Gateway
+
+    User->>Architect: "Buy 3 Laptop Pro 15 units from best vendor"
+
+    Architect->>Governor: delegate: pre-flight policy check
+    Governor->>PolicyEngine: evaluate_procurement_policy({category: "hardware", amount_usd: 3840, user_id: "emp-42"})
+    PolicyEngine-->>Governor: {decision: ALLOW, violations: [], snapshot_hash: "a1b2c3d4e5f6g7h8"}
+    Governor-->>Architect: session_state["governor_results"] = POLICY_CLEAR
+
+    Architect->>Scout: delegate: discover vendors for "Laptop Pro 15"
+    Scout->>UCP: GET /.well-known/ucp (×4 vendors)
+    UCP-->>Scout: VendorEndpoint list (TechCorp, EuroTech, NordHardware, ShadowHardware)
+    Scout-->>Architect: session_state["scout_results"] = [4 vendors, sorted by price]
+
+    Architect->>Sentinel: delegate: verify all 4 vendors
+    Sentinel->>BMS: verify_vendor_compliance("TechCorp Nordic")
+    BMS-->>Sentinel: {status: APPROVED, compliance_hash: "a3f9..."}
+    Sentinel->>PolicyEngine: evaluate_vendor_policy({name: "TechCorp Nordic", country: "US"}, 3840)
+    PolicyEngine-->>Sentinel: {decision: ALLOW, violations: []}
+    Sentinel->>BMS: verify_vendor_compliance("NordHardware AS")
+    BMS-->>Sentinel: {status: APPROVED, compliance_hash: "c18d..."}
+    Sentinel->>PolicyEngine: evaluate_vendor_policy({name: "NordHardware AS", country: "NO"}, 3840)
+    PolicyEngine-->>Sentinel: {decision: ALLOW, violations: []}
+    Sentinel->>BMS: verify_vendor_compliance("ShadowHardware")
+    BMS-->>Sentinel: {status: REJECTED, reason: AML_BLACKLIST}
+
+    Note over Sentinel: ShadowHardware rejected by BMS.<br/>Cheaper options (NordHardware) remain APPROVED.
+
+    Sentinel-->>Architect: session_state["sentinel_results"] = SENTINEL_APPROVED (NordHardware selected)
+
+    Architect->>Closer: delegate: settle with NordHardware AS ($1,280 × 3)
+    Closer->>PolicyEngine: evaluate_payment_policy({amount_usd: 3840}, user_id="emp-42")
+    PolicyEngine-->>Closer: {decision: ALLOW, violations: []}
+    Closer->>AP2: generate_intent_mandate(vendor_id="v-003", amount=3840.00, compliance_hash="c18d...")
+    AP2-->>Closer: IntentMandate {id: uuid, proof: {ecdsa-p256, signature}}
+    Closer->>AP2: settle_cart_mandate(mandate)
+    AP2-->>Closer: {settlement_id: "AP2-3X7K...", status: SETTLED}
+    Closer-->>Architect: session_state["closer_results"] = SETTLEMENT_CONFIRMED
+
+    Architect-->>User: ✅ Purchased 3× Laptop Pro 15 from NordHardware AS\n   Amount: $3,840.00 USD\n   Settlement ID: AP2-3X7K...\n   Note: ShadowHardware excluded (AML blacklist)
+```
+
+---
+
+## Scenario 2 — Policy Block (Governor halts at pre-flight)
+
+```mermaid
+sequenceDiagram
+    actor User as 👤 Enterprise User
+    participant Architect as 🏛️ Architect
+    participant Governor as ⚖️ Governor
+    participant PolicyEngine as 📋 Policy Engine
+    participant Scout as 🔭 Scout
+
+    User->>Architect: "Buy military-grade hardware from RusTech vendor"
+
+    Architect->>Governor: delegate: pre-flight policy check
+    Governor->>PolicyEngine: evaluate_procurement_policy({category: "military_hardware", amount_usd: 12000, user_id: "emp-99"})
+    PolicyEngine-->>Governor: {decision: BLOCK, violations: [{rule: CATEGORY_ALLOWLIST, reason: "military_hardware not in allow-list"}, {rule: SPENDING_LIMIT, reason: "$12,000 exceeds $5,000 transaction limit"}]}
+    Governor-->>Architect: session_state["governor_results"] = POLICY_BLOCKED
+
+    Note over Architect: ⛔ governor_results = POLICY_BLOCKED<br/>Pipeline halted — Scout never called
+
+    Architect-->>User: ⛔ Request blocked by policy engine\n   Violations:\n   • Category "military_hardware" not in allow-list\n   • Amount $12,000 exceeds transaction limit ($5,000)\n   No vendors were contacted. No payment was initiated.
+```
+
+---
+
+## Scenario 3 — Compliance Block (Sentinel → Closer aborts)
+
+```mermaid
+sequenceDiagram
+    actor User as 👤 Enterprise User
+    participant Architect as 🏛️ Architect
+    participant Governor as ⚖️ Governor
+    participant PolicyEngine as 📋 Policy Engine
+    participant Scout as 🔭 Scout
+    participant UCP as 🌐 UCP Network
+    participant Sentinel as 🛡️ Sentinel
+    participant BMS as 🏦 BMS Compliance DB
+    participant Closer as 💳 Closer
+
+    User->>Architect: "Buy laptops from ShadowHardware only"
+
+    Architect->>Governor: delegate: pre-flight policy check
+    Governor->>PolicyEngine: evaluate_procurement_policy({category: "hardware", amount_usd: 2500, user_id: "emp-77"})
+    PolicyEngine-->>Governor: {decision: ALLOW, violations: []}
+    Governor-->>Architect: session_state["governor_results"] = POLICY_CLEAR
+
+    Architect->>Scout: delegate: discover for "ShadowHardware laptops"
+    Scout->>UCP: GET /.well-known/ucp
+    UCP-->>Scout: [ShadowHardware only — vendor ID v-999]
+    Scout-->>Architect: session_state["scout_results"] = [ShadowHardware]
+
+    Architect->>Sentinel: delegate: verify ShadowHardware
+    Sentinel->>BMS: verify_vendor_compliance("ShadowHardware")
+    BMS-->>Sentinel: {status: REJECTED, reason: AML_BLACKLIST}
+    Sentinel->>PolicyEngine: evaluate_vendor_policy({name: "ShadowHardware", country: "KP"}, 2500)
+    PolicyEngine-->>Sentinel: {decision: BLOCK, violations: [{rule: GEO_RESTRICTION, reason: "Country KP is blocked"}]}
+
+    Note over Sentinel: ⛔ COMPLIANCE_BLOCKED + POLICY_BLOCKED<br/>AML blacklist AND geo-restriction — no approved vendors
+
+    Sentinel-->>Architect: session_state["sentinel_results"] = COMPLIANCE_BLOCKED
+
+    Architect->>Closer: delegate (pipeline continues to Closer)
+    Note over Closer: Reads COMPLIANCE_BLOCKED from sentinel_results<br/>No payment tools called
+    Closer-->>Architect: session_state["closer_results"] = PAYMENT_ABORTED
+
+    Architect-->>User: ⛔ Transaction blocked\n   Vendor: ShadowHardware\n   Reasons: AML_BLACKLIST + GEO_RESTRICTION (KP)\n   No payment was initiated.\n   Please contact the compliance team.
+```
+
+---
+
+## Session State Handoff
+
+ADK passes data between agents via `session_state`. Here is the key state written at each step:
+
+| Agent | Key Written | Possible Values |
+| :--- | :--- | :--- |
+| Governor | `governor_results` | `POLICY_CLEAR` / `POLICY_WARNINGS` / `POLICY_REVIEW_REQUIRED` / `POLICY_BLOCKED` |
+| Scout | `scout_results` | List of `VendorEndpoint` dicts, sorted by price |
+| Sentinel | `sentinel_results` | `SENTINEL_APPROVED` / `COMPLIANCE_BLOCKED` / `POLICY_BLOCKED` / `SENTINEL_REVIEW_REQUIRED` |
+| Closer | `closer_results` | `SETTLEMENT_CONFIRMED` / `PAYMENT_PENDING_REVIEW` / `PAYMENT_ABORTED` |
+
+## Pipeline Rules
+
+- The Architect always runs all four agents in sequence (Governor → Scout → Sentinel → Closer).
+- **Closer** checks `governor_results` and `sentinel_results` before calling any payment tool. If either contains `POLICY_BLOCKED` or `COMPLIANCE_BLOCKED`, it outputs `PAYMENT_ABORTED` immediately.
+- Blocking at the Governor stage does not prevent Scout/Sentinel from running (ADK `SequentialAgent` executes all sub-agents), but Closer will still abort the payment.
+- Policy rules are stored in `tmp/policies.json` and managed via the `/policies` REST API (`X-Admin-Token` required for mutations).
 
 ## Happy Path — Successful Procurement
 

--- a/kagent.yaml
+++ b/kagent.yaml
@@ -65,6 +65,11 @@ spec:
               value: europe-north1
             - name: GOOGLE_GENAI_USE_VERTEXAI
               value: "1"
+            - name: AURA_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aura-admin-token
+                  key: token
           resources:
             requests:
               cpu: 250m
@@ -136,15 +141,23 @@ metadata:
     component: closer
     role: settlement
 spec:
-  description: "Handles AP2 payment settlement with Intent Mandate generation."
+  description: "Handles AP2 payment settlement with payment policy evaluation and Intent Mandate generation."
   modelConfig:
     name: gemini-2-flash-vertexai
   systemPrompt: |
     You are the Closer agent in the Aura procurement system.
-    If COMPLIANCE_BLOCKED is present in context: output PAYMENT_ABORTED immediately.
-    Otherwise: generate an IntentMandate and settle via AP2.
-    Report SETTLEMENT_CONFIRMED with settlement_id on success.
+    Check governor_results and sentinel_results for POLICY_BLOCKED or COMPLIANCE_BLOCKED first.
+    If either is present: output PAYMENT_ABORTED immediately.
+    Otherwise: call evaluate_payment_policy, then generate an IntentMandate and settle via AP2.
+    Report SETTLEMENT_CONFIRMED, PAYMENT_PENDING_REVIEW, or PAYMENT_ABORTED.
   tools:
+    - name: evaluate_payment_policy
+      description: "Evaluate a payment mandate against approval thresholds and daily spend limits."
+      type: McpServer
+      mcpServer:
+        toolServer: aura-tool-server
+        toolNames:
+          - evaluate_payment_policy
     - name: generate_intent_mandate
       description: "Generate a W3C Verifiable Credential Intent Mandate for AP2 payment."
       type: McpServer
@@ -173,6 +186,11 @@ spec:
               value: europe-north1
             - name: GOOGLE_GENAI_USE_VERTEXAI
               value: "1"
+            - name: AURA_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aura-admin-token
+                  key: token
           resources:
             requests:
               cpu: 250m
@@ -198,9 +216,11 @@ spec:
     name: gemini-2-flash-vertexai
   systemPrompt: |
     You are Architect, the root orchestrator of Project Aura.
-    Coordinate the Scout → Sentinel → Closer pipeline.
-    Always prioritise compliance. Report outcome clearly to the user.
+    Coordinate the Governor → Scout → Sentinel → Closer pipeline.
+    Always prioritise compliance and governance. Report outcome clearly to the user.
   agentTeam:
+    - name: governor
+      namespace: aura
     - name: scout
       namespace: aura
     - name: sentinel
@@ -221,6 +241,11 @@ spec:
               value: europe-north1
             - name: GOOGLE_GENAI_USE_VERTEXAI
               value: "1"
+            - name: AURA_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aura-admin-token
+                  key: token
           resources:
             requests:
               cpu: 500m

--- a/main.py
+++ b/main.py
@@ -11,14 +11,17 @@ Also exports `root_agent` at module level for `adk web` dev UI auto-discovery.
 from __future__ import annotations
 
 import os
+import time
 import uuid
 from contextlib import asynccontextmanager
+from dataclasses import asdict
 from typing import AsyncIterator
 import logging
 
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Security, status
 from fastapi.responses import StreamingResponse
+from fastapi.security import APIKeyHeader
 from pydantic import BaseModel
 
 from google.adk.runners import Runner
@@ -32,6 +35,7 @@ from tools.intent_tools import (
 )
 from tools.auth_tools import AuthIdentity, require_procurement_identity
 from tools.session_tools import build_session_service
+from tools.policy_store import PolicyRule, PolicyStore, ReviewStore, RuleType, Severity
 
 load_dotenv()
 
@@ -197,3 +201,159 @@ async def run_procurement_stream(
                         yield f"data: {part.text}\n\n"
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
+# ── Policy API — admin auth ───────────────────────────────────────────────────
+
+_api_key_header = APIKeyHeader(name="X-Admin-Token", auto_error=False)
+
+
+def _require_admin_token(token: str | None = Security(_api_key_header)) -> str:
+    expected = os.getenv("AURA_ADMIN_TOKEN", "").strip()
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Admin token not configured on this server.",
+        )
+    if token != expected:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid or missing X-Admin-Token header.",
+        )
+    return token
+
+
+# ── Policy API — Pydantic models ──────────────────────────────────────────────
+
+
+class PolicyRuleCreate(BaseModel):
+    id: str
+    name: str
+    rule_type: str
+    enabled: bool = True
+    severity: str
+    parameters: dict
+    description: str = ""
+
+
+class PolicyRuleUpdate(BaseModel):
+    name: str | None = None
+    enabled: bool | None = None
+    severity: str | None = None
+    parameters: dict | None = None
+    description: str | None = None
+
+
+class PolicyRuleResponse(BaseModel):
+    id: str
+    name: str
+    rule_type: str
+    enabled: bool
+    severity: str
+    parameters: dict
+    description: str
+    created_at: float
+
+
+class ReviewResolution(BaseModel):
+    note: str = ""
+
+
+# ── Policy CRUD endpoints ─────────────────────────────────────────────────────
+
+
+@app.get("/policies", response_model=list[PolicyRuleResponse])
+async def list_policies() -> list[PolicyRuleResponse]:
+    """List all active policy rules."""
+    return [PolicyRuleResponse(**r.to_dict()) for r in PolicyStore.get_instance().get_all_rules()]
+
+
+@app.post("/policies", response_model=PolicyRuleResponse, status_code=201)
+async def create_policy(
+    body: PolicyRuleCreate,
+    _: str = Depends(_require_admin_token),
+) -> PolicyRuleResponse:
+    """Create a new policy rule (admin only)."""
+    try:
+        rule = PolicyRule(
+            id=body.id,
+            name=body.name,
+            rule_type=RuleType(body.rule_type),
+            enabled=body.enabled,
+            severity=Severity(body.severity),
+            parameters=body.parameters,
+            description=body.description,
+            created_at=time.time(),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    PolicyStore.get_instance().add_rule(rule)
+    return PolicyRuleResponse(**rule.to_dict())
+
+
+@app.get("/policies/{rule_id}", response_model=PolicyRuleResponse)
+async def get_policy(rule_id: str) -> PolicyRuleResponse:
+    """Get a single policy rule by ID."""
+    rule = PolicyStore.get_instance().get_rule(rule_id)
+    if rule is None:
+        raise HTTPException(status_code=404, detail=f"Policy rule '{rule_id}' not found.")
+    return PolicyRuleResponse(**rule.to_dict())
+
+
+@app.put("/policies/{rule_id}", response_model=PolicyRuleResponse)
+async def update_policy(
+    rule_id: str,
+    body: PolicyRuleUpdate,
+    _: str = Depends(_require_admin_token),
+) -> PolicyRuleResponse:
+    """Partially update a policy rule (admin only)."""
+    updates = {k: v for k, v in body.model_dump().items() if v is not None}
+    rule = PolicyStore.get_instance().update_rule(rule_id, updates)
+    if rule is None:
+        raise HTTPException(status_code=404, detail=f"Policy rule '{rule_id}' not found.")
+    return PolicyRuleResponse(**rule.to_dict())
+
+
+@app.delete("/policies/{rule_id}", status_code=204)
+async def delete_policy(
+    rule_id: str,
+    _: str = Depends(_require_admin_token),
+) -> None:
+    """Delete a policy rule (admin only)."""
+    if not PolicyStore.get_instance().delete_rule(rule_id):
+        raise HTTPException(status_code=404, detail=f"Policy rule '{rule_id}' not found.")
+
+
+# ── Review queue endpoints ────────────────────────────────────────────────────
+
+
+@app.get("/reviews")
+async def list_reviews() -> list[dict]:
+    """List pending review items."""
+    return [asdict(item) for item in ReviewStore.get_instance().get_pending()]
+
+
+@app.post("/reviews/{review_id}/approve")
+async def approve_review(
+    review_id: str,
+    body: ReviewResolution,
+    _: str = Depends(_require_admin_token),
+) -> dict:
+    """Approve a queued payment review (admin only)."""
+    item = ReviewStore.get_instance().resolve(review_id, approved=True, note=body.note)
+    if item is None:
+        raise HTTPException(status_code=404, detail=f"Review '{review_id}' not found.")
+    return asdict(item)
+
+
+@app.post("/reviews/{review_id}/reject")
+async def reject_review(
+    review_id: str,
+    body: ReviewResolution,
+    _: str = Depends(_require_admin_token),
+) -> dict:
+    """Reject a queued payment review (admin only)."""
+    item = ReviewStore.get_instance().resolve(review_id, approved=False, note=body.note)
+    if item is None:
+        raise HTTPException(status_code=404, detail=f"Review '{review_id}' not found.")
+    return asdict(item)

--- a/tests/test_policy_tools.py
+++ b/tests/test_policy_tools.py
@@ -1,0 +1,342 @@
+"""
+Tests for tools/policy_tools.py — all six rule types.
+
+Uses monkeypatch to inject a fresh PolicyStore per test so singleton state
+never bleeds between test classes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tools.policy_store import PolicyRule, RuleType, Severity
+from tools.policy_tools import (
+    DailySpendStore,
+    RateLimitStore,
+    evaluate_payment_policy,
+    evaluate_procurement_policy,
+    evaluate_vendor_policy,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_store(*extra_rules: PolicyRule):
+    """Return a fresh PolicyStore mock pre-loaded with given rules."""
+    from tools.policy_store import PolicyStore
+
+    obj = object.__new__(PolicyStore)
+    object.__setattr__(obj, "_rules", {r.id: r for r in extra_rules})
+    object.__setattr__(obj, "_rlock", __import__("threading").Lock())
+    return obj
+
+
+def _patch_store(monkeypatch, *rules: PolicyRule):
+    store = _make_store(*rules)
+    monkeypatch.setattr(
+        "tools.policy_tools.PolicyStore.get_instance",
+        lambda: store,
+    )
+    return store
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    """Reset RateLimitStore and DailySpendStore before each test."""
+    RateLimitStore._instance = None
+    DailySpendStore._instance = None
+    yield
+    RateLimitStore._instance = None
+    DailySpendStore._instance = None
+
+
+# ── SPENDING_LIMIT ─────────────────────────────────────────────────────────────
+
+
+class TestSpendingLimit:
+    _rule = PolicyRule(
+        id="r-spend",
+        name="Spending Limit",
+        rule_type=RuleType.SPENDING_LIMIT,
+        enabled=True,
+        severity=Severity.BLOCK,
+        parameters={"max_transaction_usd": 5000, "max_daily_usd": 20000},
+        description="",
+    )
+
+    def test_allow_within_limit(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_procurement_policy({"amount_usd": 4999, "user_id": "u1"})
+        assert result["decision"] == "ALLOW"
+
+    def test_block_over_limit(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_procurement_policy({"amount_usd": 6000, "user_id": "u2"})
+        assert result["decision"] == "BLOCK"
+        assert any("limit" in v["reason"].lower() for v in result["violations"])
+
+    def test_boundary_exact_limit_allows(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_procurement_policy({"amount_usd": 5000, "user_id": "u3"})
+        assert result["decision"] == "ALLOW"
+
+
+# ── GEO_RESTRICTION ────────────────────────────────────────────────────────────
+
+
+class TestGeoRestriction:
+    _rule = PolicyRule(
+        id="r-geo",
+        name="Geo Restriction",
+        rule_type=RuleType.GEO_RESTRICTION,
+        enabled=True,
+        severity=Severity.BLOCK,
+        parameters={"blocked_country_codes": ["IR", "KP", "RU", "SY"]},
+        description="",
+    )
+
+    def test_blocked_country(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_vendor_policy({"name": "VendorX", "country": "RU"})
+        assert result["decision"] == "BLOCK"
+        assert any("RU" in v["reason"] for v in result["violations"])
+
+    def test_allowed_country(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_vendor_policy({"name": "VendorY", "country": "NO"})
+        assert result["decision"] == "ALLOW"
+        assert result["violations"] == []
+
+    def test_all_four_sanctioned_codes_block(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        for code in ("IR", "KP", "RU", "SY"):
+            result = evaluate_vendor_policy({"name": "V", "country": code})
+            assert result["decision"] == "BLOCK", f"Expected BLOCK for {code}"
+
+
+# ── CATEGORY_ALLOWLIST ─────────────────────────────────────────────────────────
+
+
+class TestCategoryAllowlist:
+    _rule = PolicyRule(
+        id="r-cat",
+        name="Category Allowlist",
+        rule_type=RuleType.CATEGORY_ALLOWLIST,
+        enabled=True,
+        severity=Severity.BLOCK,
+        parameters={"allowed_categories": ["hardware", "electronics", "saas"]},
+        description="",
+    )
+
+    def test_approved_category(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_procurement_policy({"category": "hardware", "user_id": "u1"})
+        assert result["decision"] == "ALLOW"
+
+    def test_denied_category(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_procurement_policy({"category": "weapons", "user_id": "u1"})
+        assert result["decision"] == "BLOCK"
+        assert any("allow-list" in v["reason"].lower() for v in result["violations"])
+
+    def test_missing_category_skips_check(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_procurement_policy({"user_id": "u1"})
+        assert result["decision"] == "ALLOW"
+
+
+# ── APPROVAL_THRESHOLD ─────────────────────────────────────────────────────────
+
+
+class TestApprovalThreshold:
+    _rule = PolicyRule(
+        id="r-thresh",
+        name="Approval Threshold",
+        rule_type=RuleType.APPROVAL_THRESHOLD,
+        enabled=True,
+        severity=Severity.REVIEW,
+        parameters={
+            "auto_approve_below_usd": 1000,
+            "review_above_usd": 1000,
+            "block_above_usd": 5000,
+        },
+        description="",
+    )
+
+    def test_auto_approve_below_threshold(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_payment_policy({"amount_usd": 500}, user_id="u1")
+        assert result["decision"] == "ALLOW"
+
+    def test_review_in_middle_band(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_payment_policy({"amount_usd": 2000}, user_id="u1")
+        assert result["decision"] == "REVIEW"
+
+    def test_block_above_ceiling(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_payment_policy({"amount_usd": 6000}, user_id="u1")
+        assert result["decision"] == "BLOCK"
+
+    def test_vendor_policy_review_for_mid_amount(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_vendor_policy({"name": "V", "country": "NO"}, requested_amount=1500)
+        assert result["decision"] == "REVIEW"
+
+
+# ── CERTIFICATION_REQUIRED ─────────────────────────────────────────────────────
+
+
+class TestCertificationRequired:
+    _rule = PolicyRule(
+        id="r-cert",
+        name="Certifications",
+        rule_type=RuleType.CERTIFICATION_REQUIRED,
+        enabled=True,
+        severity=Severity.WARN,
+        parameters={"requirements": {"hardware": ["ISO9001"], "electronics": ["RoHS", "CE"]}},
+        description="",
+    )
+
+    def test_cert_present_no_violation(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_vendor_policy(
+            {"name": "V", "capability": "hardware", "certifications": ["ISO9001"]}
+        )
+        assert result["decision"] == "ALLOW"
+        assert result["violations"] == []
+
+    def test_cert_missing_warns(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_vendor_policy(
+            {"name": "V", "capability": "hardware", "certifications": []}
+        )
+        assert result["decision"] == "WARN"
+        assert any("ISO9001" in v["reason"] for v in result["violations"])
+
+    def test_saas_no_requirement_allows(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_vendor_policy(
+            {"name": "V", "capability": "saas", "certifications": []}
+        )
+        assert result["decision"] == "ALLOW"
+
+
+# ── RATE_LIMIT ─────────────────────────────────────────────────────────────────
+
+
+class TestRateLimit:
+    _rule = PolicyRule(
+        id="r-rate",
+        name="Rate Limit",
+        rule_type=RuleType.RATE_LIMIT,
+        enabled=True,
+        severity=Severity.BLOCK,
+        parameters={"max_requests_per_hour": 2, "max_requests_per_day": 5},
+        description="",
+    )
+
+    def test_within_limit_allows(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        r1 = evaluate_procurement_policy({"user_id": "ua"})
+        r2 = evaluate_procurement_policy({"user_id": "ua"})
+        assert r1["decision"] == "ALLOW"
+        assert r2["decision"] == "ALLOW"
+
+    def test_exceeds_hourly_blocks(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        evaluate_procurement_policy({"user_id": "ub"})
+        evaluate_procurement_policy({"user_id": "ub"})
+        result = evaluate_procurement_policy({"user_id": "ub"})
+        assert result["decision"] == "BLOCK"
+        assert any("rate limit" in v["reason"].lower() for v in result["violations"])
+
+    def test_different_users_are_independent(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        for _ in range(2):
+            evaluate_procurement_policy({"user_id": "uc"})
+        result = evaluate_procurement_policy({"user_id": "ud"})
+        assert result["decision"] == "ALLOW"
+
+
+# ── DAILY_SPEND_LIMIT ──────────────────────────────────────────────────────────
+
+
+class TestDailySpendLimit:
+    _rule = PolicyRule(
+        id="r-daily",
+        name="Daily Spend",
+        rule_type=RuleType.SPENDING_LIMIT,
+        enabled=True,
+        severity=Severity.BLOCK,
+        parameters={"max_transaction_usd": 99999, "max_daily_usd": 10000},
+        description="",
+    )
+
+    def test_daily_total_not_exceeded(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        DailySpendStore.get_instance().record_spend("ue", 5000)
+        result = evaluate_payment_policy({"amount_usd": 4000}, user_id="ue")
+        assert result["decision"] == "ALLOW"
+
+    def test_daily_total_exceeded_blocks(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        DailySpendStore.get_instance().record_spend("uf", 8000)
+        result = evaluate_payment_policy({"amount_usd": 3000}, user_id="uf")
+        assert result["decision"] == "BLOCK"
+
+
+# ── SNAPSHOT_HASH ──────────────────────────────────────────────────────────────
+
+
+class TestSnapshotHash:
+    _rule = PolicyRule(
+        id="r-snap",
+        name="Some Rule",
+        rule_type=RuleType.SPENDING_LIMIT,
+        enabled=True,
+        severity=Severity.BLOCK,
+        parameters={"max_transaction_usd": 1000, "max_daily_usd": 5000},
+        description="",
+    )
+
+    def test_snapshot_hash_present_and_16_chars(self, monkeypatch):
+        _patch_store(monkeypatch, self._rule)
+        result = evaluate_procurement_policy({"amount_usd": 500, "user_id": "u1"})
+        assert "snapshot_hash" in result
+        assert len(result["snapshot_hash"]) == 16
+
+    def test_snapshot_hash_changes_after_update(self, monkeypatch):
+        store = _patch_store(monkeypatch, self._rule)
+        h1 = store.get_snapshot_hash()
+        store._rules["r-snap"].parameters["max_transaction_usd"] = 2000
+        h2 = store.get_snapshot_hash()
+        assert h1 != h2
+
+
+# ── DISABLED_RULES ─────────────────────────────────────────────────────────────
+
+
+class TestDisabledRules:
+    def test_disabled_rule_is_skipped(self, monkeypatch):
+        disabled = PolicyRule(
+            id="r-disabled",
+            name="Disabled Geo",
+            rule_type=RuleType.GEO_RESTRICTION,
+            enabled=False,
+            severity=Severity.BLOCK,
+            parameters={"blocked_country_codes": ["NO"]},
+            description="",
+        )
+        _patch_store(monkeypatch, disabled)
+        result = evaluate_vendor_policy({"name": "V", "country": "NO"})
+        assert result["decision"] == "ALLOW"
+        assert result["violations"] == []

--- a/tools/policy_store.py
+++ b/tools/policy_store.py
@@ -1,0 +1,287 @@
+"""
+Policy Store — persistent, thread-safe rule registry for the Aura Policy Engine.
+
+All rules are stored in tmp/policies.json via atomic writes.
+The module exposes two singletons:
+  - PolicyStore  — CRUD over PolicyRule objects
+  - ReviewStore  — queue for transactions that require human review
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+_POLICY_FILE = Path(__file__).parent.parent / "tmp" / "policies.json"
+
+
+class RuleType(str, Enum):
+    SPENDING_LIMIT = "SPENDING_LIMIT"
+    GEO_RESTRICTION = "GEO_RESTRICTION"
+    CATEGORY_ALLOWLIST = "CATEGORY_ALLOWLIST"
+    APPROVAL_THRESHOLD = "APPROVAL_THRESHOLD"
+    CERTIFICATION_REQUIRED = "CERTIFICATION_REQUIRED"
+    RATE_LIMIT = "RATE_LIMIT"
+
+
+class Severity(str, Enum):
+    WARN = "WARN"
+    REVIEW = "REVIEW"
+    BLOCK = "BLOCK"
+
+
+@dataclass
+class PolicyRule:
+    id: str
+    name: str
+    rule_type: RuleType
+    enabled: bool
+    severity: Severity
+    parameters: dict[str, Any]
+    description: str
+    created_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["rule_type"] = self.rule_type.value
+        d["severity"] = self.severity.value
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PolicyRule":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            rule_type=RuleType(data["rule_type"]),
+            enabled=data["enabled"],
+            severity=Severity(data["severity"]),
+            parameters=data["parameters"],
+            description=data.get("description", ""),
+            created_at=data.get("created_at", time.time()),
+        )
+
+
+def _default_rules() -> list[PolicyRule]:
+    now = time.time()
+    return [
+        PolicyRule(
+            id="rule-spending-limit",
+            name="Transaction Spending Limit",
+            rule_type=RuleType.SPENDING_LIMIT,
+            enabled=True,
+            severity=Severity.BLOCK,
+            parameters={"max_transaction_usd": 5000, "max_daily_usd": 20000},
+            description="Block single transactions above $5,000 and daily spend above $20,000.",
+            created_at=now,
+        ),
+        PolicyRule(
+            id="rule-geo-restriction",
+            name="Geographic Restriction",
+            rule_type=RuleType.GEO_RESTRICTION,
+            enabled=True,
+            severity=Severity.BLOCK,
+            parameters={"blocked_country_codes": ["IR", "KP", "RU", "SY"]},
+            description="Block vendors headquartered in sanctioned countries.",
+            created_at=now,
+        ),
+        PolicyRule(
+            id="rule-category-allowlist",
+            name="Category Allowlist",
+            rule_type=RuleType.CATEGORY_ALLOWLIST,
+            enabled=True,
+            severity=Severity.BLOCK,
+            parameters={
+                "allowed_categories": [
+                    "hardware",
+                    "electronics",
+                    "computer_components",
+                    "office_supplies",
+                    "saas",
+                    "cloud_infrastructure",
+                ]
+            },
+            description="Only allow procurement in approved product categories.",
+            created_at=now,
+        ),
+        PolicyRule(
+            id="rule-approval-threshold",
+            name="Approval Threshold",
+            rule_type=RuleType.APPROVAL_THRESHOLD,
+            enabled=True,
+            severity=Severity.REVIEW,
+            parameters={
+                "auto_approve_below_usd": 1000,
+                "review_above_usd": 1000,
+                "block_above_usd": 5000,
+            },
+            description="Auto-approve under $1k; route to review queue $1k–$5k; block above $5k.",
+            created_at=now,
+        ),
+        PolicyRule(
+            id="rule-certification-required",
+            name="Vendor Certification Requirements",
+            rule_type=RuleType.CERTIFICATION_REQUIRED,
+            enabled=True,
+            severity=Severity.WARN,
+            parameters={
+                "requirements": {
+                    "hardware": ["ISO9001"],
+                    "electronics": ["RoHS", "CE"],
+                }
+            },
+            description="Warn when a vendor lacks required certifications for the product category.",
+            created_at=now,
+        ),
+        PolicyRule(
+            id="rule-rate-limit",
+            name="Request Rate Limit",
+            rule_type=RuleType.RATE_LIMIT,
+            enabled=True,
+            severity=Severity.BLOCK,
+            parameters={"max_requests_per_hour": 5, "max_requests_per_day": 20},
+            description="Block users who exceed the hourly or daily request rate.",
+            created_at=now,
+        ),
+    ]
+
+
+class PolicyStore:
+    _instance: "PolicyStore | None" = None
+    _instance_lock: threading.Lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._rules: dict[str, PolicyRule] = {}
+        self._rlock = threading.Lock()
+        self._load()
+
+    @classmethod
+    def get_instance(cls) -> "PolicyStore":
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    # ── persistence ────────────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        if not _POLICY_FILE.exists():
+            for rule in _default_rules():
+                self._rules[rule.id] = rule
+            self._flush()
+            return
+        try:
+            data = json.loads(_POLICY_FILE.read_text())
+            for item in data:
+                rule = PolicyRule.from_dict(item)
+                self._rules[rule.id] = rule
+        except Exception:
+            for rule in _default_rules():
+                self._rules[rule.id] = rule
+
+    def _flush(self) -> None:
+        _POLICY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _POLICY_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps([r.to_dict() for r in self._rules.values()], indent=2))
+        os.replace(tmp, _POLICY_FILE)
+
+    # ── CRUD ───────────────────────────────────────────────────────────────
+
+    def add_rule(self, rule: PolicyRule) -> PolicyRule:
+        with self._rlock:
+            self._rules[rule.id] = rule
+            self._flush()
+            return rule
+
+    def get_rule(self, rule_id: str) -> PolicyRule | None:
+        return self._rules.get(rule_id)
+
+    def get_all_rules(self) -> list[PolicyRule]:
+        return list(self._rules.values())
+
+    def update_rule(self, rule_id: str, updates: dict[str, Any]) -> PolicyRule | None:
+        with self._rlock:
+            rule = self._rules.get(rule_id)
+            if rule is None:
+                return None
+            for key, val in updates.items():
+                if key == "rule_type":
+                    rule.rule_type = RuleType(val)
+                elif key == "severity":
+                    rule.severity = Severity(val)
+                elif hasattr(rule, key):
+                    setattr(rule, key, val)
+            self._flush()
+            return rule
+
+    def delete_rule(self, rule_id: str) -> bool:
+        with self._rlock:
+            if rule_id not in self._rules:
+                return False
+            del self._rules[rule_id]
+            self._flush()
+            return True
+
+    def get_snapshot_hash(self) -> str:
+        raw = json.dumps(
+            [r.to_dict() for r in sorted(self._rules.values(), key=lambda x: x.id)],
+            sort_keys=True,
+        )
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+# ── Review Store ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ReviewItem:
+    id: str
+    session_id: str
+    user_id: str
+    decision_context: dict[str, Any]
+    created_at: float = field(default_factory=time.time)
+    status: str = "pending"
+    resolved_at: float | None = None
+    resolution_note: str = ""
+
+
+class ReviewStore:
+    _instance: "ReviewStore | None" = None
+    _instance_lock: threading.Lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._items: dict[str, ReviewItem] = {}
+        self._rlock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "ReviewStore":
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def add_item(self, item: ReviewItem) -> ReviewItem:
+        with self._rlock:
+            self._items[item.id] = item
+            return item
+
+    def get_pending(self) -> list[ReviewItem]:
+        return [i for i in self._items.values() if i.status == "pending"]
+
+    def resolve(self, review_id: str, approved: bool, note: str = "") -> ReviewItem | None:
+        with self._rlock:
+            item = self._items.get(review_id)
+            if item is None:
+                return None
+            item.status = "approved" if approved else "rejected"
+            item.resolved_at = time.time()
+            item.resolution_note = note
+            return item

--- a/tools/policy_tools.py
+++ b/tools/policy_tools.py
@@ -1,0 +1,360 @@
+"""
+Policy Tools — evaluate procurement, vendor, and payment policies.
+
+Three callable tools consumed by Governor, Sentinel, and Closer agents:
+  - evaluate_procurement_policy(request)  — Governor pre-flight gate
+  - evaluate_vendor_policy(vendor, requested_amount)  — Sentinel gate
+  - evaluate_payment_policy(mandate, user_id)  — Closer gate
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from tools.policy_store import PolicyStore, RuleType, Severity
+
+
+# ── Decision types ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class PolicyViolation:
+    rule_id: str
+    rule_name: str
+    severity: str
+    reason: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PolicyDecision:
+    decision: str  # ALLOW | WARN | REVIEW | BLOCK
+    violations: list[PolicyViolation] = field(default_factory=list)
+    evaluated_rules: list[str] = field(default_factory=list)
+    snapshot_hash: str = ""
+
+
+_SEVERITY_RANK = {Severity.WARN: 1, Severity.REVIEW: 2, Severity.BLOCK: 3}
+
+
+def _worst_decision(violations: list[PolicyViolation]) -> str:
+    if not violations:
+        return "ALLOW"
+    worst = max(violations, key=lambda v: _SEVERITY_RANK.get(Severity(v.severity), 0))
+    return worst.severity  # WARN | REVIEW | BLOCK
+
+
+def _make_decision(violations: list[PolicyViolation], evaluated: list[str], snapshot_hash: str) -> dict[str, Any]:
+    decision = _worst_decision(violations)
+    return asdict(
+        PolicyDecision(
+            decision=decision,
+            violations=[asdict(v) for v in violations],  # type: ignore[arg-type]
+            evaluated_rules=evaluated,
+            snapshot_hash=snapshot_hash,
+        )
+    )
+
+
+# ── In-memory rate-limit state ──────────────────────────────────────────────────
+
+
+class RateLimitStore:
+    _instance: "RateLimitStore | None" = None
+    _lock: threading.Lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._hourly: dict[str, deque[float]] = {}
+        self._daily: dict[str, deque[float]] = {}
+        self._rlock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "RateLimitStore":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def check_and_record(self, user_id: str, max_per_hour: int, max_per_day: int) -> tuple[bool, str]:
+        """Return (allowed, reason). Records the request if allowed."""
+        now = time.time()
+        with self._rlock:
+            hourly = self._hourly.setdefault(user_id, deque())
+            daily = self._daily.setdefault(user_id, deque())
+            # Evict old timestamps
+            while hourly and now - hourly[0] > 3600:
+                hourly.popleft()
+            while daily and now - daily[0] > 86400:
+                daily.popleft()
+
+            if len(hourly) >= max_per_hour:
+                return False, f"Rate limit exceeded: {len(hourly)} requests in last hour (max {max_per_hour})"
+            if len(daily) >= max_per_day:
+                return False, f"Rate limit exceeded: {len(daily)} requests today (max {max_per_day})"
+
+            hourly.append(now)
+            daily.append(now)
+            return True, ""
+
+
+# ── Daily spend tracking ────────────────────────────────────────────────────────
+
+
+class DailySpendStore:
+    _instance: "DailySpendStore | None" = None
+    _lock: threading.Lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._spends: dict[str, list[tuple[float, float]]] = {}
+        self._rlock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "DailySpendStore":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def get_daily_total(self, user_id: str) -> float:
+        now = time.time()
+        entries = self._spends.get(user_id, [])
+        return sum(amt for ts, amt in entries if now - ts <= 86400)
+
+    def record_spend(self, user_id: str, amount: float) -> None:
+        with self._rlock:
+            self._spends.setdefault(user_id, []).append((time.time(), amount))
+
+
+# ── Tool: evaluate_procurement_policy ──────────────────────────────────────────
+
+
+def evaluate_procurement_policy(request: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate pre-flight procurement policy rules for a purchase request.
+
+    Called by the Governor agent before Scout discovers vendors.
+
+    Args:
+        request: Dict with optional keys:
+            - category (str): Product category
+            - amount_usd (float): Transaction amount
+            - user_id (str): User or session identifier
+
+    Returns:
+        PolicyDecision dict with decision, violations, evaluated_rules, snapshot_hash.
+    """
+    store = PolicyStore.get_instance()
+    snapshot_hash = store.get_snapshot_hash()
+    violations: list[PolicyViolation] = []
+    evaluated: list[str] = []
+
+    category = request.get("category", "")
+    amount_usd = float(request.get("amount_usd", 0))
+    user_id = str(request.get("user_id", "unknown"))
+
+    for rule in store.get_all_rules():
+        if not rule.enabled:
+            continue
+
+        if rule.rule_type == RuleType.CATEGORY_ALLOWLIST and category:
+            evaluated.append(rule.id)
+            allowed = rule.parameters.get("allowed_categories", [])
+            if category not in allowed:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=f"Category '{category}' is not in the allow-list: {allowed}",
+                    details={"category": category, "allowed": allowed},
+                ))
+
+        elif rule.rule_type == RuleType.SPENDING_LIMIT and amount_usd > 0:
+            evaluated.append(rule.id)
+            max_tx = rule.parameters.get("max_transaction_usd", float("inf"))
+            if amount_usd > max_tx:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=f"Transaction ${amount_usd:,.2f} exceeds limit ${max_tx:,.2f}",
+                    details={"amount_usd": amount_usd, "max_transaction_usd": max_tx},
+                ))
+
+        elif rule.rule_type == RuleType.RATE_LIMIT:
+            evaluated.append(rule.id)
+            max_hour = rule.parameters.get("max_requests_per_hour", 999)
+            max_day = rule.parameters.get("max_requests_per_day", 9999)
+            allowed_rl, reason = RateLimitStore.get_instance().check_and_record(user_id, max_hour, max_day)
+            if not allowed_rl:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=reason,
+                    details={"user_id": user_id},
+                ))
+
+    return _make_decision(violations, evaluated, snapshot_hash)
+
+
+# ── Tool: evaluate_vendor_policy ───────────────────────────────────────────────
+
+
+def evaluate_vendor_policy(vendor: dict[str, Any], requested_amount: float = 0.0) -> dict[str, Any]:
+    """Evaluate vendor-specific policy rules (geo-restriction, certifications, thresholds).
+
+    Called by the Sentinel agent for each candidate vendor.
+
+    Args:
+        vendor: Dict with optional keys:
+            - country (str): ISO 3166-1 alpha-2 country code
+            - capability (str): Product capability / category
+            - certifications (list[str]): Certifications the vendor holds
+        requested_amount: Transaction amount in USD.
+
+    Returns:
+        PolicyDecision dict.
+    """
+    store = PolicyStore.get_instance()
+    snapshot_hash = store.get_snapshot_hash()
+    violations: list[PolicyViolation] = []
+    evaluated: list[str] = []
+
+    country = vendor.get("country", "").upper()
+    capability = vendor.get("capability", "")
+    certifications = set(vendor.get("certifications", []))
+
+    for rule in store.get_all_rules():
+        if not rule.enabled:
+            continue
+
+        if rule.rule_type == RuleType.GEO_RESTRICTION and country:
+            evaluated.append(rule.id)
+            blocked = rule.parameters.get("blocked_country_codes", [])
+            if country in blocked:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=f"Vendor country {country} is blocked (sanctioned/restricted).",
+                    details={"country": country, "blocked_codes": blocked},
+                ))
+
+        elif rule.rule_type == RuleType.CERTIFICATION_REQUIRED and capability:
+            evaluated.append(rule.id)
+            requirements: dict[str, list[str]] = rule.parameters.get("requirements", {})
+            required = requirements.get(capability, [])
+            missing = [c for c in required if c not in certifications]
+            if missing:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=f"Vendor missing required certifications for '{capability}': {missing}",
+                    details={"capability": capability, "missing": missing},
+                ))
+
+        elif rule.rule_type == RuleType.APPROVAL_THRESHOLD and requested_amount > 0:
+            evaluated.append(rule.id)
+            block_above = rule.parameters.get("block_above_usd", float("inf"))
+            review_above = rule.parameters.get("review_above_usd", float("inf"))
+            if requested_amount > block_above:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=Severity.BLOCK.value,
+                    reason=f"Amount ${requested_amount:,.2f} exceeds block threshold ${block_above:,.2f}",
+                    details={"amount": requested_amount, "block_above_usd": block_above},
+                ))
+            elif requested_amount > review_above:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=f"Amount ${requested_amount:,.2f} requires review (above ${review_above:,.2f})",
+                    details={"amount": requested_amount, "review_above_usd": review_above},
+                ))
+
+    return _make_decision(violations, evaluated, snapshot_hash)
+
+
+# ── Tool: evaluate_payment_policy ──────────────────────────────────────────────
+
+
+def evaluate_payment_policy(mandate: dict[str, Any], user_id: str = "unknown") -> dict[str, Any]:
+    """Evaluate payment-stage policy rules before AP2 settlement.
+
+    Called by the Closer agent after mandate generation, before settlement.
+
+    Args:
+        mandate: Dict with optional keys:
+            - amount_usd (float): Payment amount (top-level shorthand)
+            - constraints.amount (float): Amount from IntentMandate structure
+        user_id: User or session identifier for daily spend tracking.
+
+    Returns:
+        PolicyDecision dict.
+    """
+    store = PolicyStore.get_instance()
+    snapshot_hash = store.get_snapshot_hash()
+    violations: list[PolicyViolation] = []
+    evaluated: list[str] = []
+
+    # Accept both flat {amount_usd: X} and nested IntentMandate {constraints: {amount: X}}
+    amount_usd = float(
+        mandate.get("amount_usd")
+        or mandate.get("constraints", {}).get("amount", 0)
+        or 0
+    )
+
+    for rule in store.get_all_rules():
+        if not rule.enabled:
+            continue
+
+        if rule.rule_type == RuleType.APPROVAL_THRESHOLD and amount_usd > 0:
+            evaluated.append(rule.id)
+            block_above = rule.parameters.get("block_above_usd", float("inf"))
+            review_above = rule.parameters.get("review_above_usd", float("inf"))
+            auto_approve = rule.parameters.get("auto_approve_below_usd", 0)
+            if amount_usd > block_above:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=Severity.BLOCK.value,
+                    reason=f"Payment ${amount_usd:,.2f} exceeds block ceiling ${block_above:,.2f}",
+                    details={"amount": amount_usd, "block_above_usd": block_above},
+                ))
+            elif amount_usd > review_above and amount_usd > auto_approve:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=f"Payment ${amount_usd:,.2f} requires review (above ${review_above:,.2f})",
+                    details={"amount": amount_usd, "review_above_usd": review_above},
+                ))
+
+        elif rule.rule_type == RuleType.SPENDING_LIMIT and amount_usd > 0:
+            evaluated.append(rule.id)
+            max_daily = rule.parameters.get("max_daily_usd", float("inf"))
+            daily_store = DailySpendStore.get_instance()
+            daily_total = daily_store.get_daily_total(user_id)
+            if daily_total + amount_usd > max_daily:
+                violations.append(PolicyViolation(
+                    rule_id=rule.id,
+                    rule_name=rule.name,
+                    severity=rule.severity.value,
+                    reason=(
+                        f"Daily spend limit exceeded: existing ${daily_total:,.2f} + "
+                        f"new ${amount_usd:,.2f} > limit ${max_daily:,.2f}"
+                    ),
+                    details={"daily_total": daily_total, "amount_usd": amount_usd, "max_daily_usd": max_daily},
+                ))
+            else:
+                daily_store.record_spend(user_id, amount_usd)
+
+    return _make_decision(violations, evaluated, snapshot_hash)


### PR DESCRIPTION
Implements the policy engine described in issue #15.

## Summary

- **Governor agent** — new pre-flight gate (Governor → Scout → Sentinel → Closer pipeline)
- **Policy rules** — 6 default rules: SPENDING_LIMIT, GEO_RESTRICTION, CATEGORY_ALLOWLIST, APPROVAL_THRESHOLD, CERTIFICATION_REQUIRED, RATE_LIMIT
- **Sentinel** — now calls `evaluate_vendor_policy` alongside BMS compliance check
- **Closer** — now calls `evaluate_payment_policy` before AP2 settlement
- **REST API** — `/policies` CRUD + `/reviews` queue (admin-only mutations via `X-Admin-Token`)
- **K8s** — Governor CRD + `aura-admin-token` Secret in `kagent.yaml`
- **Tests** — 27 new unit tests, 140 total passing (1 pre-existing Redis env failure unchanged)
- **Docs** — `AGENT_FLOW.md` rewritten with 3 Mermaid sequence diagrams

Closes #15